### PR TITLE
Implement HOOK_STOP.

### DIFF
--- a/htp/hooks.h
+++ b/htp/hooks.h
@@ -43,10 +43,12 @@
 #define HOOK_ERROR      HTP_ERROR
 #define HOOK_OK         HTP_OK
 #define HOOK_DECLINED   HTP_DECLINED
+#define HOOK_STOP       HTP_STOP
 #else
 #define HOOK_ERROR      -1
 #define HOOK_OK          0
 #define HOOK_DECLINED    1
+#define HOOK_STOP        4
 #endif
 
 typedef struct htp_hook_t htp_hook_t;

--- a/htp/htp.h
+++ b/htp/htp.h
@@ -75,6 +75,7 @@ typedef struct htp_uri_t htp_uri_t;
 #define HTP_DATA                1
 #define HTP_DATA_OTHER          2
 #define HTP_DECLINED            3
+#define HTP_STOP                4
 
 #define PROTOCOL_UNKNOWN        -1
 #define HTTP_0_9                9
@@ -203,6 +204,7 @@ typedef struct htp_uri_t htp_uri_t;
 #define STREAM_STATE_ERROR          3
 #define STREAM_STATE_TUNNEL         4
 #define STREAM_STATE_DATA_OTHER     5
+#define STREAM_STATE_STOP           6
 #define STREAM_STATE_DATA           9
 
 #define URL_DECODER_PRESERVE_PERCENT            0

--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -435,9 +435,16 @@ int htp_connp_REQ_BODY_DETERMINE(htp_connp_t *connp) {
     // Run hook REQUEST_HEADERS
     int rc = hook_run_all(connp->cfg->hook_request_headers, connp);
     if (rc != HOOK_OK) {
-        htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-            "Request headers callback returned error (%d)", rc);
-        return HTP_ERROR;
+        switch (rc) {
+            case HOOK_STOP:
+                return HTP_STOP;
+            case HOOK_ERROR:
+            case HOOK_DECLINED:
+            default:
+                htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                    "Request headers callback returned error (%d)", rc);
+                return HTP_ERROR;
+        }
     }
 
     return HTP_OK;
@@ -534,9 +541,16 @@ int htp_connp_REQ_HEADERS(htp_connp_t *connp) {
                     // Run hook REQUEST_TRAILER
                     int rc = hook_run_all(connp->cfg->hook_request_trailer, connp);
                     if (rc != HOOK_OK) {
-                        htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-                            "Request trailer callback returned error (%d)", rc);
-                        return HTP_ERROR;
+                        switch (rc) {
+                            case HOOK_STOP:
+                                return HTP_STOP;
+                            case HOOK_ERROR:
+                            case HOOK_DECLINED:
+                            default:
+                                htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                                    "Request headers callback returned error (%d)", rc);
+                                return HTP_ERROR;
+                        }
                     }
 
                     // We've completed parsing this request
@@ -704,9 +718,16 @@ int htp_connp_REQ_LINE(htp_connp_t *connp) {
                 // Run hook REQUEST_URI_NORMALIZE
                 int rc = hook_run_all(connp->cfg->hook_request_uri_normalize, connp);
                 if (rc != HOOK_OK) {
-                    htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-                            "Request URI normalize callback returned error (%d)", rc);
-                    return HTP_ERROR;
+                    switch (rc) {
+                        case HOOK_STOP:
+                            return HTP_STOP;
+                        case HOOK_ERROR:
+                        case HOOK_DECLINED:
+                        default:
+                            htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                                "Request headers callback returned error (%d)", rc);
+                            return HTP_ERROR;
+                    }
                 }
 
                 // Now is a good time to generate request_uri_normalized, before we finalize
@@ -773,9 +794,16 @@ int htp_connp_REQ_LINE(htp_connp_t *connp) {
             // Run hook REQUEST_LINE
             int rc = hook_run_all(connp->cfg->hook_request_line, connp);
             if (rc != HOOK_OK) {
-                htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-                    "Request line callback returned error (%d)", rc);
-                return HTP_ERROR;
+                switch (rc) {
+                    case HOOK_STOP:
+                        return HTP_STOP;
+                    case HOOK_ERROR:
+                    case HOOK_DECLINED:
+                    default:
+                        htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                            "Request headers callback returned error (%d)", rc);
+                        return HTP_ERROR;
+                }
             }
 
             // Clean up.
@@ -815,9 +843,16 @@ int htp_connp_REQ_IDLE(htp_connp_t * connp) {
         // Run hook REQUEST
         int rc = hook_run_all(connp->cfg->hook_request, connp);
         if (rc != HOOK_OK) {
-            htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-                "Request callback returned error (%d)", rc);
-            return HTP_ERROR;
+            switch (rc) {
+                case HOOK_STOP:
+                    return HTP_STOP;
+                case HOOK_ERROR:
+                case HOOK_DECLINED:
+                default:
+                    htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                        "Request headers callback returned error (%d)", rc);
+                    return HTP_ERROR;
+            }
         }
 
         // Clean-up
@@ -860,9 +895,16 @@ int htp_connp_REQ_IDLE(htp_connp_t * connp) {
     // Run hook TRANSACTION_START
     int rc = hook_run_all(connp->cfg->hook_transaction_start, connp);
     if (rc != HOOK_OK) {
-        htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-            "Transaction start callback returned error (%d)", rc);
-        return HTP_ERROR;
+        switch (rc) {
+            case HOOK_STOP:
+                return HTP_STOP;
+            case HOOK_ERROR:
+            case HOOK_DECLINED:
+            default:
+                htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                    "Request headers callback returned error (%d)", rc);
+                return HTP_ERROR;
+        }
     }
 
     // Change state into request line parsing
@@ -896,6 +938,13 @@ int htp_connp_req_data(htp_connp_t *connp, htp_time_t *timestamp, unsigned char 
     fprintf(stderr, "htp_connp_req_data(connp->in_status %x)\n", connp->in_status);
     fprint_raw_data(stderr, __FUNCTION__, data, len);
     #endif
+
+    // Return if the connection is in stop state.
+    if (connp->in_status == STREAM_STATE_STOP) {
+        htp_log(connp, HTP_LOG_MARK, HTP_LOG_INFO, 0, "Inbound parser is in STREAM_STATE_STOP");
+
+        return STREAM_STATE_STOP;
+    }
 
     // Return if the connection had a fatal error earlier
     if (connp->in_status == STREAM_STATE_ERROR) {
@@ -1008,6 +1057,17 @@ int htp_connp_req_data(htp_connp_t *connp, htp_time_t *timestamp, unsigned char 
 
                     return STREAM_STATE_DATA_OTHER;
                 }
+            }
+
+            // Check for stop
+            if (rc == HTP_STOP) {
+                #ifdef HTP_DEBUG
+                fprintf(stderr, "htp_connp_req_data: returning STREAM_STATE_STOP\n");
+                #endif
+
+                connp->in_status = STREAM_STATE_STOP;
+
+                return STREAM_STATE_STOP;
             }
 
             // If we're here that means we've encountered an error.

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -46,10 +46,17 @@
 static int htp_connp_RES_BODY_DECOMPRESSOR_CALLBACK(htp_tx_data_t *d) {
     // Invoke all callbacks    
     int rc = htp_res_run_hook_body_data(d->tx->connp, d);
-    if (rc != HTP_OK) {
-        htp_log(d->tx->connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-            "Response body data callback returned error (%d)", rc);
-        return HTP_ERROR;
+    if (rc != HOOK_OK) {
+        switch (rc) {
+            case HOOK_STOP:
+                return HTP_STOP;
+            case HOOK_ERROR:
+            case HOOK_DECLINED:
+            default:
+                htp_log(d->tx->connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                    "Request headers callback returned error (%d)", rc);
+                return HTP_ERROR;
+        }
     }
 
     return HTP_OK;
@@ -101,9 +108,16 @@ int htp_connp_RES_BODY_CHUNKED_DATA(htp_connp_t *connp) {
                 // Send data to callbacks                
                 int rc = htp_res_run_hook_body_data(connp, &d);
                 if (rc != HOOK_OK) {
-                    htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-                        "Response body data callback returned error (%d)", rc);
-                    return HTP_ERROR;
+                    switch (rc) {
+                        case HOOK_STOP:
+                            return HTP_STOP;
+                        case HOOK_ERROR:
+                        case HOOK_DECLINED:
+                        default:
+                            htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                                "Request headers callback returned error (%d)", rc);
+                            return HTP_ERROR;
+                    }
                 }
             }
 
@@ -124,9 +138,16 @@ int htp_connp_RES_BODY_CHUNKED_DATA(htp_connp_t *connp) {
                     // Send data to callbacks                    
                     int rc = htp_res_run_hook_body_data(connp, &d);
                     if (rc != HOOK_OK) {
-                        htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-                            "Response body data callback returned error (%d)", rc);
-                        return HTP_ERROR;
+                        switch (rc) {
+                            case HOOK_STOP:
+                                return HTP_STOP;
+                            case HOOK_ERROR:
+                            case HOOK_DECLINED:
+                            default:
+                                htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                                    "Request headers callback returned error (%d)", rc);
+                                return HTP_ERROR;
+                        }
                     }
                 }
 
@@ -207,9 +228,16 @@ int htp_connp_RES_BODY_IDENTITY(htp_connp_t *connp) {
                 } else {                    
                     int rc = htp_res_run_hook_body_data(connp, &d);
                     if (rc != HOOK_OK) {
-                        htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-                            "Response body data callback returned error (%d)", rc);
-                        return HTP_ERROR;
+                        switch (rc) {
+                            case HOOK_STOP:
+                                return HTP_STOP;
+                            case HOOK_ERROR:
+                            case HOOK_DECLINED:
+                            default:
+                                htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                                    "Request headers callback returned error (%d)", rc);
+                                return HTP_ERROR;
+                        }
                     }
                 }
             }
@@ -246,9 +274,16 @@ int htp_connp_RES_BODY_IDENTITY(htp_connp_t *connp) {
                         } else {                            
                             int rc = htp_res_run_hook_body_data(connp, &d);
                             if (rc != HOOK_OK) {
-                                htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-                                    "Response body data callback returned error (%d)", rc);
-                                return HTP_ERROR;
+                                switch (rc) {
+                                    case HOOK_STOP:
+                                        return HTP_STOP;
+                                    case HOOK_ERROR:
+                                    case HOOK_DECLINED:
+                                    default:
+                                        htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                                            "Request headers callback returned error (%d)", rc);
+                                        return HTP_ERROR;
+                                }
                             }
                         }
                     }
@@ -425,10 +460,16 @@ int htp_connp_RES_BODY_DETERMINE(htp_connp_t *connp) {
     // Run hook RESPONSE_HEADERS_COMPLETE
     int rc = hook_run_all(connp->cfg->hook_response_headers, connp);
     if (rc != HOOK_OK) {
-        htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-            "Response headers callback returned error (%d)", rc);
-
-        return HTP_ERROR;
+        switch (rc) {
+            case HOOK_STOP:
+                return HTP_STOP;
+            case HOOK_ERROR:
+            case HOOK_DECLINED:
+            default:
+                htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                    "Request headers callback returned error (%d)", rc);
+                return HTP_ERROR;
+        }
     }
 
     // Start decompression engines if decompression is still enabled (the user
@@ -523,9 +564,16 @@ int htp_connp_RES_HEADERS(htp_connp_t * connp) {
                     // Run hook response_TRAILER
                     int rc = hook_run_all(connp->cfg->hook_response_trailer, connp);
                     if (rc != HOOK_OK) {
-                        htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-                            "Response trailer callback returned error (%d)", rc);
-                        return HTP_ERROR;
+                        switch (rc) {
+                            case HOOK_STOP:
+                                return HTP_STOP;
+                            case HOOK_ERROR:
+                            case HOOK_DECLINED:
+                            default:
+                                htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                                    "Request headers callback returned error (%d)", rc);
+                                return HTP_ERROR;
+                        }
                     }
 
                     // We've completed parsing this response
@@ -695,9 +743,16 @@ int htp_connp_RES_LINE(htp_connp_t * connp) {
             // Run hook RESPONSE_LINE
             int rc = hook_run_all(connp->cfg->hook_response_line, connp);
             if (rc != HOOK_OK) {
-                htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-                    "Response line callback returned error (%d)", rc);
-                return HTP_ERROR;
+                switch (rc) {
+                    case HOOK_STOP:
+                        return HTP_STOP;
+                    case HOOK_ERROR:
+                    case HOOK_DECLINED:
+                    default:
+                        htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                            "Request headers callback returned error (%d)", rc);
+                        return HTP_ERROR;
+                }
             }
 
             // Clean up.
@@ -749,10 +804,17 @@ int htp_connp_RES_IDLE(htp_connp_t * connp) {
 
         // Run hook RESPONSE
         int rc = hook_run_all(connp->cfg->hook_response, connp);
-        if (rc != HTP_OK) {
-            htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-                "Response callback returned error (%d)", rc);
-            return HTP_ERROR;
+        if (rc != HOOK_OK) {
+            switch (rc) {
+                case HOOK_STOP:
+                    return HTP_STOP;
+                case HOOK_ERROR:
+                case HOOK_DECLINED:
+                default:
+                    htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                        "Request headers callback returned error (%d)", rc);
+                    return HTP_ERROR;
+            }
         }
 
         if (connp->cfg->tx_auto_destroy) {
@@ -837,6 +899,13 @@ int htp_connp_res_data(htp_connp_t *connp, htp_time_t *timestamp, unsigned char 
     fprint_raw_data(stderr, __FUNCTION__, data, len);
     #endif
 
+    // Return if the connection is in stop state
+    if (connp->out_status == STREAM_STATE_STOP) {
+        htp_log(connp, HTP_LOG_MARK, HTP_LOG_INFO, 0, "Outbound parser is in STREAM_STATE_STOP");
+
+        return STREAM_STATE_STOP;
+    }
+
     // Return if the connection has had a fatal error
     if (connp->out_status == STREAM_STATE_ERROR) {
         htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0, "Outbound parser is in STREAM_STATE_ERROR");
@@ -918,6 +987,17 @@ int htp_connp_res_data(htp_connp_t *connp, htp_time_t *timestamp, unsigned char 
                 connp->out_status = STREAM_STATE_DATA;
 
                 return STREAM_STATE_DATA;
+            }
+
+            // Check for stop
+            if (rc == HTP_STOP) {
+                #ifdef HTP_DEBUG
+                fprintf(stderr, "htp_connp_res_data: returning STREAM_STATE_STOP\n");
+                #endif
+
+                connp->out_status = STREAM_STATE_STOP;
+
+                return STREAM_STATE_STOP;
             }
 
             // Check for suspended parsing


### PR DESCRIPTION
A callback which returns HOOK_STOP will put the parser in STREAM_STATE_STOP,
and will cause the parser to refuse to parse any further.

This should be just the necessary bits to implement HOOK_STOP. My earlier pull request was doing multiple things at once. I ended up deleting that repository and forking again to create this one and the only commit to it is this one.
