### PR TITLE
Fix memory leak on cookies with duplicate names

### DIFF
--- a/htp/htp_cookies.c
+++ b/htp/htp_cookies.c
@@ -73,7 +73,10 @@ int htp_parse_single_cookie_v0(htp_connp_t *connp, char *data, size_t len) {
     // Add cookie
     if (connp->cfg->parameter_processor == NULL) {
         // Add cookie directly
-        table_addn(connp->in_tx->request_cookies, name, value);
+        if (table_addn(connp->in_tx->request_cookies, name, value) == -1) {
+            bstr_free(&value);
+            bstr_free(&name);
+        }
     } else {
         // Add cookie through parameter processor
         connp->cfg->parameter_processor(connp->in_tx->request_cookies, name, value);


### PR DESCRIPTION
If a cookie fails to be added to the request_cookies table because
of insert failure or more likely a cookie with the same tag already
exists, then we are currently leaking the memory allocated to store
the the current cookies name and value strings.  This patch fixes
this by evaluating the return value of table_addn,

This fix could also start a discussion about what to do in the case of 
cookies with duplicate tags, present in the request either by incorrect 
header generation by the browser, or the addition of cookies by a 
proxy that unfortunately conflict with the browsers cookies.

In the end, the raw headers are what get written onwards to the server 
by the proxy, if the author uses htp_tx_generate_request_headers_raw,
so the duplicate cookies will be passed on to the server unchanged.
But during processing by libhtp, the duplicate cookie will be skipped, with 
or without this patch, and thus will evade analysis.

It may be wise to at least add a flag to the request transaction with a 
meaning similar to HTP_REQUEST_SMUGGLING, which can 
provide a library user another factor for making a security policy 
decision.
