### PR TITLE
Fix htp_tx_generate_request_headers_raw null dereference.

### DIFF
--- a/htp/htp_util.c
+++ b/htp/htp_util.c
@@ -2099,7 +2099,8 @@ bstr *htp_tx_generate_request_headers_raw(htp_tx_t *tx) {
         len += bstr_len(hl->line);
     }
 
-    len += bstr_len(tx->request_headers_sep);
+    if (tx->request_headers_sep)
+        len += bstr_len(tx->request_headers_sep);
 
     request_headers_raw = bstr_alloc(len);
     if (request_headers_raw == NULL) {
@@ -2112,7 +2113,8 @@ bstr *htp_tx_generate_request_headers_raw(htp_tx_t *tx) {
         bstr_add_noex(request_headers_raw, hl->line);
     }
 
-    bstr_add_noex(request_headers_raw, tx->request_headers_sep);
+    if (tx->request_headers_sep)
+        bstr_add_noex(request_headers_raw, tx->request_headers_sep);
 
     return request_headers_raw;
 }


### PR DESCRIPTION
Fix null dereference found in a Suricata unittest DetectHttpRawHeaderTest07 (https://github.com/inliniac/suricata/blob/master/src/detect-http-raw-header.c#L480). The htp_tx_generate_request_headers_raw function is called on an incomplete request from the Suricata detection engine, leading to a null dereference as htp_tx_generate_request_headers_raw assumes tx->request_headers_sep to be initiallized.
