### PR TITLE
Support OpenBSD in configure.ac so that libiconv detection works out of ...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -122,6 +122,13 @@ case "$OS" in
                 CPPFLAGS="${CPPFLAGS} -I/usr/local/include"
                 LDFLAGS="${LDFLAGS} -L/usr/local/lib"
         ;;
+        OpenBSD*)
+                AC_MSG_RESULT(OpenBSD)
+                OS_OPENBSD="true"
+                NO_STACK_PROTECTOR="true"
+                CPPFLAGS="${CPPFLAGS} -I/usr/local/include"
+                LDFLAGS="${LDFLAGS} -L/usr/local/lib"
+        ;;
         Linux*)
                 AC_MSG_RESULT(Linux)
                 OS_LINUX="true"


### PR DESCRIPTION
...the box.

This is needed to cleanly build on OpenBSD. Further description can be found here: https://redmine.openinfosecfoundation.org/issues/881
