### PR TITLE
Fix segv caused when we have an invalid host string in host header or

### DIFF
--- a/htp/htp_util.c
+++ b/htp/htp_util.c
@@ -566,6 +566,7 @@ int htp_parse_uri_hostport(htp_connp_t *connp, bstr *hostport, htp_uri_t *uri) {
 
     if (invalid) {
         connp->in_tx->flags |= HTP_HOSTU_INVALID;
+        return HTP_OK;
     }
 
     if (htp_validate_hostname(uri->hostname) == 0) {
@@ -592,6 +593,7 @@ htp_status_t htp_parse_header_hostport(bstr *hostport, bstr **hostname, int *por
 
     if (invalid) {
         *flags |= HTP_HOSTH_INVALID;
+        return HTP_OK;
     }
 
     if (htp_validate_hostname(*hostname) == 0) {


### PR DESCRIPTION
CONNECT authority.

One way to fix this was manually check if *hostname is NULL before calling htp_validate_hostname(), or inside htp_validate_hostname(). But if we have already set the HTP_HOSTH_INVALID flag, there's no point again trying to validate the hostname and then set the flag again.
