### PR TITLE
[rfc] Memory wrappers and accounting v4

### DIFF
--- a/htp/bstr.c
+++ b/htp/bstr.c
@@ -41,7 +41,7 @@
 #include "bstr.h"
 
 bstr *bstr_alloc(size_t len) {
-    bstr *b = malloc(sizeof (bstr) + len);
+    bstr *b = htp_malloc(sizeof (bstr) + len);
     if (b == NULL) return NULL;
 
     b->len = 0;
@@ -270,7 +270,7 @@ bstr *bstr_expand(bstr *b, size_t newsize) {
     // Catch attempts to "expand" to a smaller size
     if (bstr_size(b) > newsize) return NULL;
 
-    bstr *bnew = realloc(b, sizeof (bstr) + newsize);
+    bstr *bnew = htp_realloc(b, sizeof (bstr) + newsize);
     if (bnew == NULL) return NULL;
 
     bstr_adjust_size(bnew, newsize);
@@ -280,7 +280,7 @@ bstr *bstr_expand(bstr *b, size_t newsize) {
 
 void bstr_free(bstr *b) {
     if (b == NULL) return;
-    free(b);
+    htp_free(b);
 }
 
 int bstr_index_of(const bstr *haystack, const bstr *needle) {
@@ -537,7 +537,7 @@ char *bstr_util_memdup_to_c(const void *_data, size_t len) {
     // Now copy the string into a NUL-terminated buffer.
 
     char *r, *d;
-    r = d = malloc(len + nulls + 1);
+    r = d = htp_malloc(len + nulls + 1);
     if (d == NULL) return NULL;
 
     while (len--) {
@@ -565,7 +565,7 @@ bstr *bstr_wrap_c(const char *cstr) {
 }
 
 bstr *bstr_wrap_mem(const void *data, size_t len) {
-    bstr *b = (bstr *) malloc(sizeof (bstr));
+    bstr *b = (bstr *) htp_malloc(sizeof (bstr));
     if (b == NULL) return NULL;
 
     b->size = b->len = len;

--- a/htp/bstr.c
+++ b/htp/bstr.c
@@ -280,7 +280,7 @@ bstr *bstr_expand(bstr *b, size_t newsize) {
 
 void bstr_free(bstr *b) {
     if (b == NULL) return;
-    htp_free(b);
+    htp_free(b, (sizeof (bstr) + bstr_size(b)));
 }
 
 int bstr_index_of(const bstr *haystack, const bstr *needle) {

--- a/htp/bstr.c
+++ b/htp/bstr.c
@@ -270,7 +270,7 @@ bstr *bstr_expand(bstr *b, size_t newsize) {
     // Catch attempts to "expand" to a smaller size
     if (bstr_size(b) > newsize) return NULL;
 
-    bstr *bnew = htp_realloc(b, sizeof (bstr) + newsize);
+    bstr *bnew = htp_realloc(b, sizeof (bstr) + newsize, sizeof (bstr) + bstr_size(b));
     if (bnew == NULL) return NULL;
 
     bstr_adjust_size(bnew, newsize);

--- a/htp/bstr_builder.c
+++ b/htp/bstr_builder.c
@@ -73,7 +73,7 @@ bstr_builder_t *bstr_builder_create() {
 
     bb->pieces = htp_list_create(BSTR_BUILDER_DEFAULT_SIZE);
     if (bb->pieces == NULL) {
-        htp_free(bb);
+        htp_free(bb, sizeof (bstr_builder_t));
         return NULL;
     }
 
@@ -91,7 +91,7 @@ void bstr_builder_destroy(bstr_builder_t *bb) {
 
     htp_list_destroy(bb->pieces);
 
-    htp_free(bb);
+    htp_free(bb, sizeof (bstr_builder_t));
 }
 
 size_t bstr_builder_size(const bstr_builder_t *bb) {

--- a/htp/bstr_builder.c
+++ b/htp/bstr_builder.c
@@ -68,12 +68,12 @@ void bstr_builder_clear(bstr_builder_t *bb) {
 }
 
 bstr_builder_t *bstr_builder_create() {
-    bstr_builder_t *bb = calloc(1, sizeof (bstr_builder_t));
+    bstr_builder_t *bb = htp_calloc(1, sizeof (bstr_builder_t));
     if (bb == NULL) return NULL;
 
     bb->pieces = htp_list_create(BSTR_BUILDER_DEFAULT_SIZE);
     if (bb->pieces == NULL) {
-        free(bb);
+        htp_free(bb);
         return NULL;
     }
 
@@ -91,7 +91,7 @@ void bstr_builder_destroy(bstr_builder_t *bb) {
 
     htp_list_destroy(bb->pieces);
 
-    free(bb);
+    htp_free(bb);
 }
 
 size_t bstr_builder_size(const bstr_builder_t *bb) {

--- a/htp/htp.h
+++ b/htp/htp.h
@@ -662,6 +662,8 @@ htp_status_t htp_urldecode_inplace_ex(htp_cfg_t *cfg, enum htp_decoder_ctx_t ctx
  */
 char *htp_get_version(void);
 
+uint64_t htp_memory_get_memuse(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/htp/htp_base64.c
+++ b/htp/htp_base64.c
@@ -178,7 +178,7 @@ bstr *htp_base64_decode_mem(const void *data, size_t len) {
 
     htp_base64_decoder_init(&decoder);
 
-    unsigned char *tmpstr = malloc(len);
+    unsigned char *tmpstr = htp_malloc(len);
     if (tmpstr == NULL) return NULL;
 
     int resulting_len = htp_base64_decode(&decoder, data, len, tmpstr, len);
@@ -186,7 +186,7 @@ bstr *htp_base64_decode_mem(const void *data, size_t len) {
         r = bstr_dup_mem(tmpstr, resulting_len);
     }
 
-    free(tmpstr);
+    htp_free(tmpstr);
 
     return r;
 }

--- a/htp/htp_base64.c
+++ b/htp/htp_base64.c
@@ -186,7 +186,7 @@ bstr *htp_base64_decode_mem(const void *data, size_t len) {
         r = bstr_dup_mem(tmpstr, resulting_len);
     }
 
-    htp_free(tmpstr);
+    htp_free(tmpstr, len);
 
     return r;
 }

--- a/htp/htp_config.c
+++ b/htp/htp_config.c
@@ -203,7 +203,7 @@ htp_cfg_t *htp_config_copy(htp_cfg_t *cfg) {
     if (cfg->hook_request_uri_normalize != NULL) {
         copy->hook_request_uri_normalize = htp_hook_copy(cfg->hook_request_uri_normalize);
         if (copy->hook_request_uri_normalize == NULL) {
-            free(copy);
+            htp_config_destroy(copy);
             return NULL;
         }
     }

--- a/htp/htp_config.c
+++ b/htp/htp_config.c
@@ -144,7 +144,7 @@ static unsigned char bestfit_1252[] = {
 };
 
 htp_cfg_t *htp_config_create(void) {
-    htp_cfg_t *cfg = calloc(1, sizeof (htp_cfg_t));
+    htp_cfg_t *cfg = htp_calloc(1, sizeof (htp_cfg_t));
     if (cfg == NULL) return NULL;
 
     cfg->field_limit_hard = HTP_FIELD_LIMIT_HARD;
@@ -178,7 +178,7 @@ htp_cfg_t *htp_config_copy(htp_cfg_t *cfg) {
 
     // Start by making a copy of the entire structure,
     // which is essentially a shallow copy.
-    htp_cfg_t *copy = malloc(sizeof (htp_cfg_t));
+    htp_cfg_t *copy = htp_malloc(sizeof (htp_cfg_t));
     if (copy == NULL) return NULL;
     memcpy(copy, cfg, sizeof (htp_cfg_t));
 
@@ -371,7 +371,7 @@ void htp_config_destroy(htp_cfg_t *cfg) {
     htp_hook_destroy(cfg->hook_transaction_complete);
     htp_hook_destroy(cfg->hook_log);
 
-    free(cfg);
+    htp_free(cfg);
 }
 
 void *htp_config_get_user_data(htp_cfg_t *cfg) {

--- a/htp/htp_config.c
+++ b/htp/htp_config.c
@@ -371,7 +371,7 @@ void htp_config_destroy(htp_cfg_t *cfg) {
     htp_hook_destroy(cfg->hook_transaction_complete);
     htp_hook_destroy(cfg->hook_log);
 
-    htp_free(cfg);
+    htp_free(cfg, sizeof(*cfg));
 }
 
 void *htp_config_get_user_data(htp_cfg_t *cfg) {

--- a/htp/htp_connection.c
+++ b/htp/htp_connection.c
@@ -39,12 +39,12 @@
 #include "htp_private.h"
 
 htp_conn_t *htp_conn_create(void) {
-    htp_conn_t *conn = calloc(1, sizeof (htp_conn_t));
+    htp_conn_t *conn = htp_calloc(1, sizeof (htp_conn_t));
     if (conn == NULL) return NULL;   
 
     conn->transactions = htp_list_create(16);
     if (conn->transactions == NULL) {
-        free(conn);
+        htp_free(conn);
         return NULL;
     }
 
@@ -52,7 +52,7 @@ htp_conn_t *htp_conn_create(void) {
     if (conn->messages == NULL) {
         htp_list_destroy(conn->transactions);
         conn->transactions = NULL;
-        free(conn);
+        htp_free(conn);
         return NULL;
     }
 
@@ -91,8 +91,8 @@ void htp_conn_destroy(htp_conn_t *conn) {
         // Destroy individual messages.
         for (size_t i = 0, n = htp_list_size(conn->messages); i < n; i++) {
             htp_log_t *l = htp_list_get(conn->messages, i);
-            free((void *) l->msg);
-            free(l);
+            htp_free((void *) l->msg);
+            htp_free(l);
         }
 
         htp_list_destroy(conn->messages);
@@ -100,14 +100,14 @@ void htp_conn_destroy(htp_conn_t *conn) {
     }
 
     if (conn->server_addr != NULL) {
-        free(conn->server_addr);
+        htp_free(conn->server_addr);
     }
 
     if (conn->client_addr != NULL) {
-        free(conn->client_addr);
+        htp_free(conn->client_addr);
     }
     
-    free(conn);
+    htp_free(conn);
 }
 
 htp_status_t htp_conn_open(htp_conn_t *conn, const char *client_addr, int client_port,
@@ -126,7 +126,7 @@ htp_status_t htp_conn_open(htp_conn_t *conn, const char *client_addr, int client
         conn->server_addr = strdup(server_addr);
         if (conn->server_addr == NULL) {
             if (conn->client_addr != NULL) {
-                free(conn->client_addr);
+                htp_free(conn->client_addr);
             }
 
             return HTP_ERROR;

--- a/htp/htp_connection.c
+++ b/htp/htp_connection.c
@@ -44,7 +44,7 @@ htp_conn_t *htp_conn_create(void) {
 
     conn->transactions = htp_list_create(16);
     if (conn->transactions == NULL) {
-        htp_free(conn);
+        htp_free(conn, sizeof (htp_conn_t));
         return NULL;
     }
 
@@ -52,7 +52,7 @@ htp_conn_t *htp_conn_create(void) {
     if (conn->messages == NULL) {
         htp_list_destroy(conn->transactions);
         conn->transactions = NULL;
-        htp_free(conn);
+        htp_free(conn, sizeof (htp_conn_t));
         return NULL;
     }
 
@@ -91,8 +91,8 @@ void htp_conn_destroy(htp_conn_t *conn) {
         // Destroy individual messages.
         for (size_t i = 0, n = htp_list_size(conn->messages); i < n; i++) {
             htp_log_t *l = htp_list_get(conn->messages, i);
-            htp_free((void *) l->msg);
-            htp_free(l);
+            htp_free((void *) l->msg, strlen(l->msg));
+            htp_free(l, sizeof(*l));
         }
 
         htp_list_destroy(conn->messages);
@@ -100,14 +100,14 @@ void htp_conn_destroy(htp_conn_t *conn) {
     }
 
     if (conn->server_addr != NULL) {
-        htp_free(conn->server_addr);
+        htp_free(conn->server_addr, strlen(conn->server_addr));
     }
 
     if (conn->client_addr != NULL) {
-        htp_free(conn->client_addr);
+        htp_free(conn->client_addr, strlen(conn->client_addr));
     }
     
-    htp_free(conn);
+    htp_free(conn, sizeof(htp_conn_t));
 }
 
 htp_status_t htp_conn_open(htp_conn_t *conn, const char *client_addr, int client_port,
@@ -126,7 +126,7 @@ htp_status_t htp_conn_open(htp_conn_t *conn, const char *client_addr, int client
         conn->server_addr = strdup(server_addr);
         if (conn->server_addr == NULL) {
             if (conn->client_addr != NULL) {
-                htp_free(conn->client_addr);
+                htp_free(conn->client_addr, strlen(conn->client_addr));
             }
 
             return HTP_ERROR;

--- a/htp/htp_connection.c
+++ b/htp/htp_connection.c
@@ -116,14 +116,14 @@ htp_status_t htp_conn_open(htp_conn_t *conn, const char *client_addr, int client
     if (conn == NULL) return HTP_ERROR;
 
     if (client_addr != NULL) {
-        conn->client_addr = strdup(client_addr);
+        conn->client_addr = htp_strdup(client_addr);
         if (conn->client_addr == NULL) return HTP_ERROR;
     }
 
     conn->client_port = client_port;
 
     if (server_addr != NULL) {
-        conn->server_addr = strdup(server_addr);
+        conn->server_addr = htp_strdup(server_addr);
         if (conn->server_addr == NULL) {
             if (conn->client_addr != NULL) {
                 htp_free(conn->client_addr, strlen(conn->client_addr));

--- a/htp/htp_connection_parser.c
+++ b/htp/htp_connection_parser.c
@@ -68,7 +68,7 @@ htp_connp_t *htp_connp_create(htp_cfg_t *cfg) {
     // Create a new connection.
     connp->conn = htp_conn_create();
     if (connp->conn == NULL) {
-        htp_free(connp);
+        htp_free(connp, sizeof (htp_connp_t));
         return NULL;
     }
 
@@ -87,11 +87,11 @@ void htp_connp_destroy(htp_connp_t *connp) {
     if (connp == NULL) return;
     
     if (connp->in_buf != NULL) {
-        htp_free(connp->in_buf);
+        htp_free(connp->in_buf, connp->in_buf_size);
     }
 
     if (connp->out_buf != NULL) {
-        htp_free(connp->out_buf);
+        htp_free(connp->out_buf, connp->out_buf_size);
     }
         
     if (connp->out_decompressor != NULL) {
@@ -101,10 +101,10 @@ void htp_connp_destroy(htp_connp_t *connp) {
 
     if (connp->put_file != NULL) {
         bstr_free(connp->put_file->filename);
-        htp_free(connp->put_file);
+        htp_free(connp->put_file, sizeof(*connp->put_file));
     }
 
-    htp_free(connp);
+    htp_free(connp, sizeof(htp_connp_t));
 }
 
 void htp_connp_destroy_all(htp_connp_t *connp) {

--- a/htp/htp_connection_parser.c
+++ b/htp/htp_connection_parser.c
@@ -59,7 +59,7 @@ void htp_connp_close(htp_connp_t *connp, const htp_time_t *timestamp) {
 }
 
 htp_connp_t *htp_connp_create(htp_cfg_t *cfg) {
-    htp_connp_t *connp = calloc(1, sizeof (htp_connp_t));
+    htp_connp_t *connp = htp_calloc(1, sizeof (htp_connp_t));
     if (connp == NULL) return NULL;
 
     // Use the supplied configuration structure
@@ -68,7 +68,7 @@ htp_connp_t *htp_connp_create(htp_cfg_t *cfg) {
     // Create a new connection.
     connp->conn = htp_conn_create();
     if (connp->conn == NULL) {
-        free(connp);
+        htp_free(connp);
         return NULL;
     }
 
@@ -87,11 +87,11 @@ void htp_connp_destroy(htp_connp_t *connp) {
     if (connp == NULL) return;
     
     if (connp->in_buf != NULL) {
-        free(connp->in_buf);
+        htp_free(connp->in_buf);
     }
 
     if (connp->out_buf != NULL) {
-        free(connp->out_buf);
+        htp_free(connp->out_buf);
     }
         
     if (connp->out_decompressor != NULL) {
@@ -101,10 +101,10 @@ void htp_connp_destroy(htp_connp_t *connp) {
 
     if (connp->put_file != NULL) {
         bstr_free(connp->put_file->filename);
-        free(connp->put_file);
+        htp_free(connp->put_file);
     }
 
-    free(connp);
+    htp_free(connp);
 }
 
 void htp_connp_destroy_all(htp_connp_t *connp) {

--- a/htp/htp_content_handlers.c
+++ b/htp/htp_content_handlers.c
@@ -65,7 +65,7 @@ htp_status_t htp_ch_urlencoded_callback_request_body_data(htp_tx_data_t *d) {
         for (size_t i = 0, n = htp_table_size(tx->request_urlenp_body->params); i < n; i++) {
             value = htp_table_get_index(tx->request_urlenp_body->params, i, &name);
 
-            htp_param_t *param = calloc(1, sizeof (htp_param_t));
+            htp_param_t *param = htp_calloc(1, sizeof (htp_param_t));
             if (param == NULL) return HTP_ERROR;
 
             param->name = name;
@@ -75,7 +75,7 @@ htp_status_t htp_ch_urlencoded_callback_request_body_data(htp_tx_data_t *d) {
             param->parser_data = NULL;
 
             if (htp_tx_req_add_param(tx, param) != HTP_OK) {
-                free(param);
+                htp_free(param);
                 return HTP_ERROR;
             }
         }
@@ -155,7 +155,7 @@ htp_status_t htp_ch_urlencoded_callback_request_line(htp_tx_t *tx) {
     for (size_t i = 0, n = htp_table_size(tx->request_urlenp_query->params); i < n; i++) {
         value = htp_table_get_index(tx->request_urlenp_query->params, i, &name);
 
-        htp_param_t *param = calloc(1, sizeof (htp_param_t));
+        htp_param_t *param = htp_calloc(1, sizeof (htp_param_t));
         if (param == NULL) return HTP_ERROR;
         
         param->name = name;
@@ -165,7 +165,7 @@ htp_status_t htp_ch_urlencoded_callback_request_line(htp_tx_t *tx) {
         param->parser_data = NULL;
 
         if (htp_tx_req_add_param(tx, param) != HTP_OK) {
-            free(param);
+            htp_free(param);
             return HTP_ERROR;
         }
     }
@@ -208,7 +208,7 @@ htp_status_t htp_ch_multipart_callback_request_body_data(htp_tx_data_t *d) {
 
             // Use text parameters.
             if (part->type == MULTIPART_PART_TEXT) {
-                htp_param_t *param = calloc(1, sizeof (htp_param_t));
+                htp_param_t *param = htp_calloc(1, sizeof (htp_param_t));
                 if (param == NULL) return HTP_ERROR;
                 param->name = part->name;
                 param->value = part->value;
@@ -217,7 +217,7 @@ htp_status_t htp_ch_multipart_callback_request_body_data(htp_tx_data_t *d) {
                 param->parser_data = part;
 
                 if (htp_tx_req_add_param(tx, param) != HTP_OK) {
-                    free(param);
+                    htp_free(param);
                     return HTP_ERROR;
                 }
             }

--- a/htp/htp_content_handlers.c
+++ b/htp/htp_content_handlers.c
@@ -75,7 +75,7 @@ htp_status_t htp_ch_urlencoded_callback_request_body_data(htp_tx_data_t *d) {
             param->parser_data = NULL;
 
             if (htp_tx_req_add_param(tx, param) != HTP_OK) {
-                htp_free(param);
+                htp_free(param, sizeof(htp_param_t));
                 return HTP_ERROR;
             }
         }
@@ -165,7 +165,7 @@ htp_status_t htp_ch_urlencoded_callback_request_line(htp_tx_t *tx) {
         param->parser_data = NULL;
 
         if (htp_tx_req_add_param(tx, param) != HTP_OK) {
-            htp_free(param);
+            htp_free(param, sizeof (htp_param_t));
             return HTP_ERROR;
         }
     }
@@ -217,7 +217,7 @@ htp_status_t htp_ch_multipart_callback_request_body_data(htp_tx_data_t *d) {
                 param->parser_data = part;
 
                 if (htp_tx_req_add_param(tx, param) != HTP_OK) {
-                    htp_free(param);
+                    htp_free(param, sizeof (htp_param_t));
                     return HTP_ERROR;
                 }
             }

--- a/htp/htp_core.h
+++ b/htp/htp_core.h
@@ -47,7 +47,7 @@ extern "C" {
 void *htp_malloc(size_t size);
 void *htp_calloc(size_t nmemb, size_t size);
 void *htp_realloc(void *ptr, size_t size, size_t oldsize);
-void htp_free(void *ptr);
+void htp_free(void *ptr, size_t size);
 
 typedef int htp_status_t;
 

--- a/htp/htp_core.h
+++ b/htp/htp_core.h
@@ -43,6 +43,12 @@
 extern "C" {
 #endif
 
+/* these are implemented in htp_util.c */
+void *htp_malloc(size_t size);
+void *htp_calloc(size_t nmemb, size_t size);
+void *htp_realloc(void *ptr, size_t size);
+void htp_free(void *ptr);
+
 typedef int htp_status_t;
 
 typedef struct htp_cfg_t htp_cfg_t;

--- a/htp/htp_core.h
+++ b/htp/htp_core.h
@@ -47,6 +47,7 @@ extern "C" {
 void *htp_malloc(size_t size);
 void *htp_calloc(size_t nmemb, size_t size);
 void *htp_realloc(void *ptr, size_t size, size_t oldsize);
+char *htp_strdup(const char *s);
 void htp_free(void *ptr, size_t size);
 
 typedef int htp_status_t;

--- a/htp/htp_core.h
+++ b/htp/htp_core.h
@@ -46,7 +46,7 @@ extern "C" {
 /* these are implemented in htp_util.c */
 void *htp_malloc(size_t size);
 void *htp_calloc(size_t nmemb, size_t size);
-void *htp_realloc(void *ptr, size_t size);
+void *htp_realloc(void *ptr, size_t size, size_t oldsize);
 void htp_free(void *ptr);
 
 typedef int htp_status_t;

--- a/htp/htp_decompressors.c
+++ b/htp/htp_decompressors.c
@@ -154,8 +154,8 @@ static void htp_gzip_decompressor_destroy(htp_decompressor_gzip_t *drec) {
         drec->zlib_initialized = 0;
     }
 
-    free(drec->buffer);
-    free(drec);
+    htp_free(drec->buffer);
+    htp_free(drec);
 }
 
 /**
@@ -166,15 +166,15 @@ static void htp_gzip_decompressor_destroy(htp_decompressor_gzip_t *drec) {
  * @return New htp_decompressor_t instance on success, or NULL on failure.
  */
 htp_decompressor_t *htp_gzip_decompressor_create(htp_connp_t *connp, enum htp_content_encoding_t format) {
-    htp_decompressor_gzip_t *drec = calloc(1, sizeof (htp_decompressor_gzip_t));
+    htp_decompressor_gzip_t *drec = htp_calloc(1, sizeof (htp_decompressor_gzip_t));
     if (drec == NULL) return NULL;
 
     drec->super.decompress = (int (*)(htp_decompressor_t *, htp_tx_data_t *))htp_gzip_decompressor_decompress;
     drec->super.destroy = (void (*)(htp_decompressor_t *))htp_gzip_decompressor_destroy;
 
-    drec->buffer = malloc(GZIP_BUF_SIZE);
+    drec->buffer = htp_malloc(GZIP_BUF_SIZE);
     if (drec->buffer == NULL) {
-        free(drec);
+        htp_free(drec);
         return NULL;
     }
 
@@ -194,8 +194,8 @@ htp_decompressor_t *htp_gzip_decompressor_create(htp_connp_t *connp, enum htp_co
         htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0, "GZip decompressor: inflateInit2 failed with code %d", rc);
 
         inflateEnd(&drec->stream);
-        free(drec->buffer);
-        free(drec);
+        htp_free(drec->buffer);
+        htp_free(drec);
 
         return NULL;
     }

--- a/htp/htp_decompressors.c
+++ b/htp/htp_decompressors.c
@@ -154,8 +154,8 @@ static void htp_gzip_decompressor_destroy(htp_decompressor_gzip_t *drec) {
         drec->zlib_initialized = 0;
     }
 
-    htp_free(drec->buffer);
-    htp_free(drec);
+    htp_free(drec->buffer, GZIP_BUF_SIZE);
+    htp_free(drec, sizeof (htp_decompressor_gzip_t));
 }
 
 /**
@@ -174,7 +174,7 @@ htp_decompressor_t *htp_gzip_decompressor_create(htp_connp_t *connp, enum htp_co
 
     drec->buffer = htp_malloc(GZIP_BUF_SIZE);
     if (drec->buffer == NULL) {
-        htp_free(drec);
+        htp_free(drec, sizeof (htp_decompressor_gzip_t));
         return NULL;
     }
 
@@ -194,8 +194,8 @@ htp_decompressor_t *htp_gzip_decompressor_create(htp_connp_t *connp, enum htp_co
         htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0, "GZip decompressor: inflateInit2 failed with code %d", rc);
 
         inflateEnd(&drec->stream);
-        htp_free(drec->buffer);
-        htp_free(drec);
+        htp_free(drec->buffer, GZIP_BUF_SIZE);
+        htp_free(drec, sizeof (htp_decompressor_gzip_t));
 
         return NULL;
     }

--- a/htp/htp_hooks.c
+++ b/htp/htp_hooks.c
@@ -61,7 +61,7 @@ htp_hook_t *htp_hook_create(void) {
 
     hook->callbacks = (htp_list_array_t *) htp_list_array_create(4);
     if (hook->callbacks == NULL) {
-        htp_free(hook);
+        htp_free(hook, sizeof (htp_hook_t));
         return NULL;
     }
 
@@ -72,12 +72,12 @@ void htp_hook_destroy(htp_hook_t *hook) {
     if (hook == NULL) return;
 
     for (size_t i = 0, n = htp_list_size(hook->callbacks); i < n; i++) {
-        htp_free((htp_callback_t *) htp_list_get(hook->callbacks, i));
+        htp_free((htp_callback_t *) htp_list_get(hook->callbacks, i), sizeof(htp_callback_t));
     }
 
     htp_list_array_destroy(hook->callbacks);
 
-    htp_free(hook);
+    htp_free(hook, sizeof (htp_hook_t));
 }
 
 htp_status_t htp_hook_register(htp_hook_t **hook, const htp_callback_fn_t callback_fn) {
@@ -96,7 +96,7 @@ htp_status_t htp_hook_register(htp_hook_t **hook, const htp_callback_fn_t callba
 
         *hook = htp_hook_create();
         if (*hook == NULL) {
-            htp_free(callback);
+            htp_free(callback, sizeof(htp_callback_t));
             return HTP_ERROR;
         }
     }
@@ -104,10 +104,10 @@ htp_status_t htp_hook_register(htp_hook_t **hook, const htp_callback_fn_t callba
     // Add callback 
     if (htp_list_array_push((*hook)->callbacks, callback) != HTP_OK) {
         if (hook_created) {
-            htp_free(*hook);
+            htp_free(*hook, sizeof (htp_hook_t));
         }
 
-        htp_free(callback);
+        htp_free(callback, sizeof(htp_callback_t));
 
         return HTP_ERROR;
     }

--- a/htp/htp_hooks.c
+++ b/htp/htp_hooks.c
@@ -56,12 +56,12 @@ htp_hook_t *htp_hook_copy(const htp_hook_t *hook) {
 }
 
 htp_hook_t *htp_hook_create(void) {
-    htp_hook_t *hook = calloc(1, sizeof (htp_hook_t));
+    htp_hook_t *hook = htp_calloc(1, sizeof (htp_hook_t));
     if (hook == NULL) return NULL;
 
     hook->callbacks = (htp_list_array_t *) htp_list_array_create(4);
     if (hook->callbacks == NULL) {
-        free(hook);
+        htp_free(hook);
         return NULL;
     }
 
@@ -72,18 +72,18 @@ void htp_hook_destroy(htp_hook_t *hook) {
     if (hook == NULL) return;
 
     for (size_t i = 0, n = htp_list_size(hook->callbacks); i < n; i++) {
-        free((htp_callback_t *) htp_list_get(hook->callbacks, i));
+        htp_free((htp_callback_t *) htp_list_get(hook->callbacks, i));
     }
 
     htp_list_array_destroy(hook->callbacks);
 
-    free(hook);
+    htp_free(hook);
 }
 
 htp_status_t htp_hook_register(htp_hook_t **hook, const htp_callback_fn_t callback_fn) {
     if (hook == NULL) return HTP_ERROR;
 
-    htp_callback_t *callback = calloc(1, sizeof (htp_callback_t));
+    htp_callback_t *callback = htp_calloc(1, sizeof (htp_callback_t));
     if (callback == NULL) return HTP_ERROR;
 
     callback->fn = callback_fn;
@@ -96,7 +96,7 @@ htp_status_t htp_hook_register(htp_hook_t **hook, const htp_callback_fn_t callba
 
         *hook = htp_hook_create();
         if (*hook == NULL) {
-            free(callback);
+            htp_free(callback);
             return HTP_ERROR;
         }
     }
@@ -104,10 +104,10 @@ htp_status_t htp_hook_register(htp_hook_t **hook, const htp_callback_fn_t callba
     // Add callback 
     if (htp_list_array_push((*hook)->callbacks, callback) != HTP_OK) {
         if (hook_created) {
-            free(*hook);
+            htp_free(*hook);
         }
 
-        free(callback);
+        htp_free(callback);
 
         return HTP_ERROR;
     }

--- a/htp/htp_list.c
+++ b/htp/htp_list.c
@@ -45,13 +45,13 @@ htp_list_t *htp_list_array_create(size_t size) {
     if (size == 0) return NULL;
 
     // Allocate the list structure.
-    htp_list_array_t *l = calloc(1, sizeof (htp_list_array_t));
+    htp_list_array_t *l = htp_calloc(1, sizeof (htp_list_array_t));
     if (l == NULL) return NULL;
 
     // Allocate the initial batch of elements.
-    l->elements = malloc(size * sizeof (void *));
+    l->elements = htp_malloc(size * sizeof (void *));
     if (l->elements == NULL) {
-        free(l);
+        htp_free(l);
         return NULL;
     }
 
@@ -76,8 +76,8 @@ void htp_list_array_clear(htp_list_array_t *l) {
 void htp_list_array_destroy(htp_list_array_t *l) {
     if (l == NULL) return;
 
-    free(l->elements);
-    free(l);
+    htp_free(l->elements);
+    htp_free(l);
 }
 
 void *htp_list_array_get(const htp_list_array_t *l, size_t idx) {
@@ -134,14 +134,14 @@ htp_status_t htp_list_array_push(htp_list_array_t *l, void *e) {
             // element in the list resides in the first slot. In
             // that case we just add some new space to the end,
             // adjust the max_size and that's that.
-            newblock = realloc(l->elements, new_size * sizeof (void *));
+            newblock = htp_realloc(l->elements, new_size * sizeof (void *));
             if (newblock == NULL) return HTP_ERROR;
         } else {
             // When the first element is not in the first
             // memory slot, we need to rearrange the order
             // of the elements in order to expand the storage area.
             /* coverity[suspicious_sizeof] */
-            newblock = malloc((size_t) (new_size * sizeof (void *)));
+            newblock = htp_malloc((size_t) (new_size * sizeof (void *)));
             if (newblock == NULL) return HTP_ERROR;
 
             // Copy the beginning of the list to the beginning of the new memory block
@@ -155,7 +155,7 @@ htp_status_t htp_list_array_push(htp_list_array_t *l, void *e) {
                     (void *) l->elements,
                     (size_t) (l->first * sizeof (void *)));
 
-            free(l->elements);
+            htp_free(l->elements);
         }
 
         l->first = 0;
@@ -223,7 +223,7 @@ void *htp_list_array_shift(htp_list_array_t *l) {
 // Linked list
 
 htp_list_linked_t *htp_list_linked_create(void) {
-    htp_list_linked_t *l = calloc(1, sizeof (htp_list_linked_t));
+    htp_list_linked_t *l = htp_calloc(1, sizeof (htp_list_linked_t));
     if (l == NULL) return NULL;
 
     return l;
@@ -236,14 +236,14 @@ void htp_list_linked_destroy(htp_list_linked_t *l) {
     htp_list_linked_element_t *temp = l->first;
     htp_list_linked_element_t *prev = NULL;
     while (temp != NULL) {
-        free(temp->data);
+        htp_free(temp->data);
         prev = temp;
         temp = temp->next;
-        free(prev);
+        htp_free(prev);
     }
 
     // Free the list itself
-    free(l);
+    htp_free(l);
 }
 
 int htp_list_linked_empty(const htp_list_linked_t *l) {
@@ -270,7 +270,7 @@ void *htp_list_linked_pop(htp_list_linked_t *l) {
     }
 
     r = qe->data;
-    free(qe);
+    htp_free(qe);
 
     if (qprev != NULL) {
         qprev->next = NULL;
@@ -284,7 +284,7 @@ void *htp_list_linked_pop(htp_list_linked_t *l) {
 }
 
 int htp_list_linked_push(htp_list_linked_t *l, void *e) {
-    htp_list_linked_element_t *le = calloc(1, sizeof (htp_list_linked_element_t));
+    htp_list_linked_element_t *le = htp_calloc(1, sizeof (htp_list_linked_element_t));
     if (le == NULL) return -1;
 
     // Remember the element
@@ -319,7 +319,7 @@ void *htp_list_linked_shift(htp_list_linked_t *l) {
         l->last = NULL;
     }
 
-    free(le);
+    htp_free(le);
 
     return r;
 }
@@ -355,7 +355,7 @@ int main(int argc, char **argv) {
         printf("Got: %s\n", s);
     }
 
-    free(q);
+    htp_free(q);
 
     return 0;
 }

--- a/htp/htp_list.c
+++ b/htp/htp_list.c
@@ -51,7 +51,7 @@ htp_list_t *htp_list_array_create(size_t size) {
     // Allocate the initial batch of elements.
     l->elements = htp_malloc(size * sizeof (void *));
     if (l->elements == NULL) {
-        htp_free(l);
+        htp_free(l, sizeof (htp_list_array_t));
         return NULL;
     }
 
@@ -76,8 +76,8 @@ void htp_list_array_clear(htp_list_array_t *l) {
 void htp_list_array_destroy(htp_list_array_t *l) {
     if (l == NULL) return;
 
-    htp_free(l->elements);
-    htp_free(l);
+    htp_free(l->elements, l->max_size * sizeof (void *));
+    htp_free(l, sizeof(htp_list_array_t));
 }
 
 void *htp_list_array_get(const htp_list_array_t *l, size_t idx) {
@@ -155,7 +155,7 @@ htp_status_t htp_list_array_push(htp_list_array_t *l, void *e) {
                     (void *) l->elements,
                     (size_t) (l->first * sizeof (void *)));
 
-            htp_free(l->elements);
+            htp_free(l->elements, l->max_size * sizeof (void *));
         }
 
         l->first = 0;

--- a/htp/htp_list.c
+++ b/htp/htp_list.c
@@ -134,7 +134,7 @@ htp_status_t htp_list_array_push(htp_list_array_t *l, void *e) {
             // element in the list resides in the first slot. In
             // that case we just add some new space to the end,
             // adjust the max_size and that's that.
-            newblock = htp_realloc(l->elements, new_size * sizeof (void *));
+            newblock = htp_realloc(l->elements, new_size * sizeof (void *), l->max_size * sizeof (void *));
             if (newblock == NULL) return HTP_ERROR;
         } else {
             // When the first element is not in the first

--- a/htp/htp_multipart.c
+++ b/htp/htp_multipart.c
@@ -676,7 +676,7 @@ htp_status_t htp_mpart_part_handle_data(htp_multipart_part_t *part, const unsign
                         strncpy(buf, part->parser->extract_dir, 254);
                         strncat(buf, "/libhtp-multipart-file-XXXXXX", 254 - strlen(buf));
 
-                        part->file->tmpname = strdup(buf);
+                        part->file->tmpname = htp_strdup(buf);
                         if (part->file->tmpname == NULL) {
                             bstr_free(line);
                             return HTP_ERROR;

--- a/htp/htp_multipart.c
+++ b/htp/htp_multipart.c
@@ -245,7 +245,7 @@ htp_status_t htp_mpart_part_parse_c_d(htp_multipart_part_t *part) {
                     return HTP_DECLINED;
                 }
  
-                part->file = calloc(1, sizeof (htp_file_t));
+                part->file = htp_calloc(1, sizeof (htp_file_t));
                 if (part->file == NULL) return HTP_ERROR;
 
                 part->file->fd = -1;
@@ -253,7 +253,7 @@ htp_status_t htp_mpart_part_parse_c_d(htp_multipart_part_t *part) {
 
                 part->file->filename = bstr_dup_mem(data + start, pos - start - 1);
                 if (part->file->filename == NULL) {
-                    free(part->file);
+                    htp_free(part->file);
                     return HTP_ERROR;
                 }
 
@@ -385,19 +385,19 @@ htp_status_t htp_mpartp_parse_header(htp_multipart_part_t *part, const unsigned 
     }
 
     // Now extract the name and the value.
-    htp_header_t *h = calloc(1, sizeof (htp_header_t));
+    htp_header_t *h = htp_calloc(1, sizeof (htp_header_t));
     if (h == NULL) return HTP_ERROR;
 
     h->name = bstr_dup_mem(data + name_start, name_end - name_start);
     if (h->name == NULL) {
-        free(h);
+        htp_free(h);
         return HTP_ERROR;
     }
 
     h->value = bstr_dup_mem(data + value_start, value_end - value_start);
     if (h->value == NULL) {
         bstr_free(h->name);
-        free(h);
+        htp_free(h);
         return HTP_ERROR;
     }
 
@@ -414,7 +414,7 @@ htp_status_t htp_mpartp_parse_header(htp_multipart_part_t *part, const unsigned 
         if (new_value == NULL) {
             bstr_free(h->name);
             bstr_free(h->value);
-            free(h);
+            htp_free(h);
             return HTP_ERROR;
         }
 
@@ -425,7 +425,7 @@ htp_status_t htp_mpartp_parse_header(htp_multipart_part_t *part, const unsigned 
         // The header is no longer needed.
         bstr_free(h->name);
         bstr_free(h->value);
-        free(h);
+        htp_free(h);
 
         // Keep track of same-name headers.
         h_existing->flags |= HTP_MULTIPART_PART_HEADER_REPEATED;
@@ -435,7 +435,7 @@ htp_status_t htp_mpartp_parse_header(htp_multipart_part_t *part, const unsigned 
         if (htp_table_add(part->headers, h->name, h) != HTP_OK) {
             bstr_free(h->value);
             bstr_free(h->name);
-            free(h);
+            htp_free(h);
             return HTP_ERROR;
         }
     }
@@ -450,12 +450,12 @@ htp_status_t htp_mpartp_parse_header(htp_multipart_part_t *part, const unsigned 
  * @return New part instance, or NULL on memory allocation failure.
  */
 htp_multipart_part_t *htp_mpart_part_create(htp_mpartp_t *parser) {
-    htp_multipart_part_t * part = calloc(1, sizeof (htp_multipart_part_t));
+    htp_multipart_part_t * part = htp_calloc(1, sizeof (htp_multipart_part_t));
     if (part == NULL) return NULL;
 
     part->headers = htp_table_create(4);
     if (part->headers == NULL) {
-        free(part);
+        htp_free(part);
         return NULL;
     }
 
@@ -480,10 +480,10 @@ void htp_mpart_part_destroy(htp_multipart_part_t *part, int gave_up_data) {
 
         if (part->file->tmpname != NULL) {
             unlink(part->file->tmpname);
-            free(part->file->tmpname);
+            htp_free(part->file->tmpname);
         }
 
-        free(part->file);
+        htp_free(part->file);
         part->file = NULL;
     }
 
@@ -500,13 +500,13 @@ void htp_mpart_part_destroy(htp_multipart_part_t *part, int gave_up_data) {
             h = htp_table_get_index(part->headers, i, NULL);
             bstr_free(h->name);
             bstr_free(h->value);
-            free(h);
+            htp_free(h);
         }
 
         htp_table_destroy(part->headers);
     }
 
-    free(part);
+    htp_free(part);
 }
 
 /**
@@ -855,7 +855,7 @@ static htp_status_t htp_mpartp_init_boundary(htp_mpartp_t *parser, unsigned char
     // Copy the boundary and convert it to lowercase.
 
     parser->multipart.boundary_len = len + 4;
-    parser->multipart.boundary = malloc(parser->multipart.boundary_len + 1);
+    parser->multipart.boundary = htp_malloc(parser->multipart.boundary_len + 1);
     if (parser->multipart.boundary == NULL) return HTP_ERROR;
 
     parser->multipart.boundary[0] = CR;
@@ -883,7 +883,7 @@ static htp_status_t htp_mpartp_init_boundary(htp_mpartp_t *parser, unsigned char
 htp_mpartp_t *htp_mpartp_create(htp_cfg_t *cfg, bstr *boundary, uint64_t flags) {
     if ((cfg == NULL) || (boundary == NULL)) return NULL;
 
-    htp_mpartp_t *parser = calloc(1, sizeof (htp_mpartp_t));
+    htp_mpartp_t *parser = htp_calloc(1, sizeof (htp_mpartp_t));
     if (parser == NULL) return NULL;
 
     parser->cfg = cfg;
@@ -943,7 +943,7 @@ void htp_mpartp_destroy(htp_mpartp_t *parser) {
     if (parser == NULL) return;
 
     if (parser->multipart.boundary != NULL) {
-        free(parser->multipart.boundary);
+        htp_free(parser->multipart.boundary);
     }
 
     bstr_builder_destroy(parser->boundary_pieces);
@@ -961,7 +961,7 @@ void htp_mpartp_destroy(htp_mpartp_t *parser) {
         htp_list_destroy(parser->multipart.parts);
     }
 
-    free(parser);
+    htp_free(parser);
 }
 
 /**

--- a/htp/htp_php.c
+++ b/htp/htp_php.c
@@ -106,7 +106,7 @@ htp_status_t htp_php_parameter_processor(htp_param_t *p) {
 
     // If we made any changes, free the old parameter name and put the new one in.
     if (new_name != NULL) {
-        free(p->name);
+        bstr_free(p->name);
         p->name = new_name;
     }
 

--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -211,13 +211,13 @@ static htp_status_t htp_connp_req_buffer(htp_connp_t *connp) {
     // Copy the data remaining in the buffer.
 
     if (connp->in_buf == NULL) {
-        connp->in_buf = malloc(len);
+        connp->in_buf = htp_malloc(len);
         if (connp->in_buf == NULL) return HTP_ERROR;
         memcpy(connp->in_buf, data, len);
         connp->in_buf_size = len;
     } else {
         size_t newsize = connp->in_buf_size + len;
-        unsigned char *newbuf = realloc(connp->in_buf, newsize);
+        unsigned char *newbuf = htp_realloc(connp->in_buf, newsize);
         if (newbuf == NULL) return HTP_ERROR;
         connp->in_buf = newbuf;
         memcpy(connp->in_buf + connp->in_buf_size, data, len);
@@ -268,7 +268,7 @@ static void htp_connp_req_clear_buffer(htp_connp_t *connp) {
     connp->in_current_consume_offset = connp->in_current_read_offset;
 
     if (connp->in_buf != NULL) {
-        free(connp->in_buf);
+        htp_free(connp->in_buf);
         connp->in_buf = NULL;
         connp->in_buf_size = 0;
     }

--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -217,7 +217,7 @@ static htp_status_t htp_connp_req_buffer(htp_connp_t *connp) {
         connp->in_buf_size = len;
     } else {
         size_t newsize = connp->in_buf_size + len;
-        unsigned char *newbuf = htp_realloc(connp->in_buf, newsize);
+        unsigned char *newbuf = htp_realloc(connp->in_buf, newsize, connp->in_buf_size);
         if (newbuf == NULL) return HTP_ERROR;
         connp->in_buf = newbuf;
         memcpy(connp->in_buf + connp->in_buf_size, data, len);

--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -268,7 +268,7 @@ static void htp_connp_req_clear_buffer(htp_connp_t *connp) {
     connp->in_current_consume_offset = connp->in_current_read_offset;
 
     if (connp->in_buf != NULL) {
-        htp_free(connp->in_buf);
+        htp_free(connp->in_buf, connp->in_buf_size);
         connp->in_buf = NULL;
         connp->in_buf_size = 0;
     }

--- a/htp/htp_request_generic.c
+++ b/htp/htp_request_generic.c
@@ -54,7 +54,7 @@ htp_status_t htp_process_request_header_generic(htp_connp_t *connp, unsigned cha
 
     // Now try to parse the header.
     if (htp_parse_request_header_generic(connp, h, data, len) != HTP_OK) {
-        htp_free(h);
+        htp_free(h, sizeof (htp_header_t));
         return HTP_ERROR;
     }
 
@@ -74,7 +74,7 @@ htp_status_t htp_process_request_header_generic(htp_connp_t *connp, unsigned cha
         if (new_value == NULL) {
             bstr_free(h->name);
             bstr_free(h->value);
-            htp_free(h);
+            htp_free(h, sizeof (htp_header_t));
             return HTP_ERROR;
         }
 
@@ -85,7 +85,7 @@ htp_status_t htp_process_request_header_generic(htp_connp_t *connp, unsigned cha
         // The new header structure is no longer needed.
         bstr_free(h->name);
         bstr_free(h->value);
-        htp_free(h);
+        htp_free(h, sizeof (htp_header_t));
 
         // Keep track of repeated same-name headers.
         h_existing->flags |= HTP_FIELD_REPEATED;

--- a/htp/htp_request_generic.c
+++ b/htp/htp_request_generic.c
@@ -49,12 +49,12 @@
  */
 htp_status_t htp_process_request_header_generic(htp_connp_t *connp, unsigned char *data, size_t len) {
     // Create a new header structure.
-    htp_header_t *h = calloc(1, sizeof (htp_header_t));
+    htp_header_t *h = htp_calloc(1, sizeof (htp_header_t));
     if (h == NULL) return HTP_ERROR;
 
     // Now try to parse the header.
     if (htp_parse_request_header_generic(connp, h, data, len) != HTP_OK) {
-        free(h);
+        htp_free(h);
         return HTP_ERROR;
     }
 
@@ -74,7 +74,7 @@ htp_status_t htp_process_request_header_generic(htp_connp_t *connp, unsigned cha
         if (new_value == NULL) {
             bstr_free(h->name);
             bstr_free(h->value);
-            free(h);
+            htp_free(h);
             return HTP_ERROR;
         }
 
@@ -85,7 +85,7 @@ htp_status_t htp_process_request_header_generic(htp_connp_t *connp, unsigned cha
         // The new header structure is no longer needed.
         bstr_free(h->name);
         bstr_free(h->value);
-        free(h);
+        htp_free(h);
 
         // Keep track of repeated same-name headers.
         h_existing->flags |= HTP_FIELD_REPEATED;

--- a/htp/htp_request_parsers.c
+++ b/htp/htp_request_parsers.c
@@ -120,7 +120,7 @@ int htp_header_parse_internal_strict(unsigned char *data, size_t len, htp_header
  *
  */
 htp_header_t *htp_connp_header_parse(htp_connp_t *reqp, unsigned char *data, size_t len) {
-    htp_header_t *h = calloc(1, sizeof (htp_header_t));
+    htp_header_t *h = htp_calloc(1, sizeof (htp_header_t));
     if (h == NULL) return NULL;
 
     // Parse the header line    

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -213,13 +213,13 @@ static htp_status_t htp_connp_res_buffer(htp_connp_t *connp) {
     // Copy the data remaining in the buffer.
 
     if (connp->out_buf == NULL) {
-        connp->out_buf = malloc(len);
+        connp->out_buf = htp_malloc(len);
         if (connp->out_buf == NULL) return HTP_ERROR;
         memcpy(connp->out_buf, data, len);
         connp->out_buf_size = len;
     } else {
         size_t newsize = connp->out_buf_size + len;
-        unsigned char *newbuf = realloc(connp->out_buf, newsize);
+        unsigned char *newbuf = htp_realloc(connp->out_buf, newsize);
         if (newbuf == NULL) return HTP_ERROR;
         connp->out_buf = newbuf;
         memcpy(connp->out_buf + connp->out_buf_size, data, len);
@@ -270,7 +270,7 @@ static void htp_connp_res_clear_buffer(htp_connp_t *connp) {
     connp->out_current_consume_offset = connp->out_current_read_offset;
 
     if (connp->out_buf != NULL) {
-        free(connp->out_buf);
+        htp_free(connp->out_buf);
         connp->out_buf = NULL;
         connp->out_buf_size = 0;
     }
@@ -502,7 +502,7 @@ htp_status_t htp_connp_RES_BODY_DETERMINE(htp_connp_t *connp) {
             h = htp_table_get_index(connp->out_tx->response_headers, i, NULL);
             bstr_free(h->name);
             bstr_free(h->value);
-            free(h);
+            htp_free(h);
         }
 
         htp_table_clear(connp->out_tx->response_headers);

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -219,7 +219,7 @@ static htp_status_t htp_connp_res_buffer(htp_connp_t *connp) {
         connp->out_buf_size = len;
     } else {
         size_t newsize = connp->out_buf_size + len;
-        unsigned char *newbuf = htp_realloc(connp->out_buf, newsize);
+        unsigned char *newbuf = htp_realloc(connp->out_buf, newsize, connp->out_buf_size);
         if (newbuf == NULL) return HTP_ERROR;
         connp->out_buf = newbuf;
         memcpy(connp->out_buf + connp->out_buf_size, data, len);

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -270,7 +270,7 @@ static void htp_connp_res_clear_buffer(htp_connp_t *connp) {
     connp->out_current_consume_offset = connp->out_current_read_offset;
 
     if (connp->out_buf != NULL) {
-        htp_free(connp->out_buf);
+        htp_free(connp->out_buf, connp->out_buf_size);
         connp->out_buf = NULL;
         connp->out_buf_size = 0;
     }
@@ -502,7 +502,7 @@ htp_status_t htp_connp_RES_BODY_DETERMINE(htp_connp_t *connp) {
             h = htp_table_get_index(connp->out_tx->response_headers, i, NULL);
             bstr_free(h->name);
             bstr_free(h->value);
-            htp_free(h);
+            htp_free(h, sizeof(htp_header_t));
         }
 
         htp_table_clear(connp->out_tx->response_headers);

--- a/htp/htp_response_generic.c
+++ b/htp/htp_response_generic.c
@@ -236,11 +236,11 @@ htp_status_t htp_parse_response_header_generic(htp_connp_t *connp, htp_header_t 
  */
 htp_status_t htp_process_response_header_generic(htp_connp_t *connp, unsigned char *data, size_t len) {
     // Create a new header structure.
-    htp_header_t *h = calloc(1, sizeof (htp_header_t));
+    htp_header_t *h = htp_calloc(1, sizeof (htp_header_t));
     if (h == NULL) return HTP_ERROR;
 
     if (htp_parse_response_header_generic(connp, h, data, len) != HTP_OK) {
-        free(h);
+        htp_free(h);
         return HTP_ERROR;
     }
 
@@ -260,7 +260,7 @@ htp_status_t htp_process_response_header_generic(htp_connp_t *connp, unsigned ch
         if (new_value == NULL) {
             bstr_free(h->name);
             bstr_free(h->value);
-            free(h);
+            htp_free(h);
             return HTP_ERROR;
         }
 
@@ -271,7 +271,7 @@ htp_status_t htp_process_response_header_generic(htp_connp_t *connp, unsigned ch
         // The new header structure is no longer needed.
         bstr_free(h->name);
         bstr_free(h->value);
-        free(h);
+        htp_free(h);
 
         // Keep track of repeated same-name headers.
         h_existing->flags |= HTP_FIELD_REPEATED;
@@ -280,7 +280,7 @@ htp_status_t htp_process_response_header_generic(htp_connp_t *connp, unsigned ch
         if (htp_table_add(connp->out_tx->response_headers, h->name, h) != HTP_OK) {
             bstr_free(h->name);
             bstr_free(h->value);
-            free(h);
+            htp_free(h);
             return HTP_ERROR;
         }
     }

--- a/htp/htp_response_generic.c
+++ b/htp/htp_response_generic.c
@@ -240,7 +240,7 @@ htp_status_t htp_process_response_header_generic(htp_connp_t *connp, unsigned ch
     if (h == NULL) return HTP_ERROR;
 
     if (htp_parse_response_header_generic(connp, h, data, len) != HTP_OK) {
-        htp_free(h);
+        htp_free(h, sizeof (htp_header_t));
         return HTP_ERROR;
     }
 
@@ -260,7 +260,7 @@ htp_status_t htp_process_response_header_generic(htp_connp_t *connp, unsigned ch
         if (new_value == NULL) {
             bstr_free(h->name);
             bstr_free(h->value);
-            htp_free(h);
+            htp_free(h, sizeof (htp_header_t));
             return HTP_ERROR;
         }
 
@@ -271,7 +271,7 @@ htp_status_t htp_process_response_header_generic(htp_connp_t *connp, unsigned ch
         // The new header structure is no longer needed.
         bstr_free(h->name);
         bstr_free(h->value);
-        htp_free(h);
+        htp_free(h, sizeof (htp_header_t));
 
         // Keep track of repeated same-name headers.
         h_existing->flags |= HTP_FIELD_REPEATED;
@@ -280,7 +280,7 @@ htp_status_t htp_process_response_header_generic(htp_connp_t *connp, unsigned ch
         if (htp_table_add(connp->out_tx->response_headers, h->name, h) != HTP_OK) {
             bstr_free(h->name);
             bstr_free(h->value);
-            htp_free(h);
+            htp_free(h, sizeof (htp_header_t));
             return HTP_ERROR;
         }
     }

--- a/htp/htp_table.c
+++ b/htp/htp_table.c
@@ -73,7 +73,7 @@ htp_status_t htp_table_add(htp_table_t *table, const bstr *key, const void *elem
     if (dupkey == NULL) return HTP_ERROR;
 
     if (_htp_table_add(table, dupkey, element) != HTP_OK) {
-        free(dupkey);
+        bstr_free(dupkey);
         return HTP_ERROR;
     }
 

--- a/htp/htp_table.c
+++ b/htp/htp_table.c
@@ -156,7 +156,7 @@ htp_table_t *htp_table_create(size_t size) {
     // Use a list behind the scenes.
     table->list = htp_list_array_create(size * 2);
     if (table->list == NULL) {
-        htp_free(table);
+        htp_free(table, sizeof (htp_table_t));
         return NULL;
     }
 
@@ -171,7 +171,7 @@ void htp_table_destroy(htp_table_t *table) {
     htp_list_destroy(table->list);
     table->list = NULL;
 
-    htp_free(table);
+    htp_free(table, sizeof (htp_table_t));
 }
 
 void htp_table_destroy_ex(htp_table_t *table) {

--- a/htp/htp_table.c
+++ b/htp/htp_table.c
@@ -148,7 +148,7 @@ void htp_table_clear_ex(htp_table_t *table) {
 htp_table_t *htp_table_create(size_t size) {
     if (size == 0) return NULL;
 
-    htp_table_t *table = calloc(1, sizeof (htp_table_t));
+    htp_table_t *table = htp_calloc(1, sizeof (htp_table_t));
     if (table == NULL) return NULL;
 
     table->alloc_type = HTP_TABLE_KEYS_ALLOC_UKNOWN;
@@ -156,7 +156,7 @@ htp_table_t *htp_table_create(size_t size) {
     // Use a list behind the scenes.
     table->list = htp_list_array_create(size * 2);
     if (table->list == NULL) {
-        free(table);
+        htp_free(table);
         return NULL;
     }
 
@@ -171,7 +171,7 @@ void htp_table_destroy(htp_table_t *table) {
     htp_list_destroy(table->list);
     table->list = NULL;
 
-    free(table);
+    htp_free(table);
 }
 
 void htp_table_destroy_ex(htp_table_t *table) {

--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -154,8 +154,8 @@ void htp_tx_destroy_incomplete(htp_tx_t *tx) {
     htp_param_t *param = NULL;
     for (size_t i = 0, n = htp_table_size(tx->request_params); i < n; i++) {
         param = htp_table_get_index(tx->request_params, i, NULL);
-        free(param->name);
-        free(param->value);
+        bstr_free(param->name);
+        bstr_free(param->value);
         free(param);
     }
 

--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -51,7 +51,7 @@ static bstr *copy_or_wrap_mem(const void *data, size_t len, enum htp_alloc_strat
 htp_tx_t *htp_tx_create(htp_connp_t *connp) {
     if (connp == NULL) return NULL;
 
-    htp_tx_t *tx = calloc(1, sizeof (htp_tx_t));
+    htp_tx_t *tx = htp_calloc(1, sizeof (htp_tx_t));
     if (tx == NULL) return NULL;
 
     tx->connp = connp;
@@ -137,7 +137,7 @@ void htp_tx_destroy_incomplete(htp_tx_t *tx) {
             h = htp_table_get_index(tx->request_headers, i, NULL);
             bstr_free(h->name);
             bstr_free(h->value);
-            free(h);
+            htp_free(h);
         }
 
         htp_table_destroy(tx->request_headers);
@@ -156,7 +156,7 @@ void htp_tx_destroy_incomplete(htp_tx_t *tx) {
         param = htp_table_get_index(tx->request_params, i, NULL);
         bstr_free(param->name);
         bstr_free(param->value);
-        free(param);
+        htp_free(param);
     }
 
     htp_table_destroy(tx->request_params);
@@ -190,7 +190,7 @@ void htp_tx_destroy_incomplete(htp_tx_t *tx) {
             h = htp_table_get_index(tx->response_headers, i, NULL);
             bstr_free(h->name);
             bstr_free(h->value);
-            free(h);
+            htp_free(h);
         }
 
         htp_table_destroy(tx->response_headers);
@@ -201,7 +201,7 @@ void htp_tx_destroy_incomplete(htp_tx_t *tx) {
         htp_config_destroy(tx->cfg);
     }
 
-    free(tx);
+    htp_free(tx);
 }
 
 int htp_tx_get_is_config_shared(const htp_tx_t *tx) {
@@ -277,26 +277,26 @@ htp_status_t htp_tx_req_set_header(htp_tx_t *tx, const char *name, size_t name_l
         const char *value, size_t value_len, enum htp_alloc_strategy_t alloc) {
     if ((tx == NULL) || (name == NULL) || (value == NULL)) return HTP_ERROR;
 
-    htp_header_t *h = calloc(1, sizeof (htp_header_t));
+    htp_header_t *h = htp_calloc(1, sizeof (htp_header_t));
     if (h == NULL) return HTP_ERROR;
 
     h->name = copy_or_wrap_mem(name, name_len, alloc);
     if (h->name == NULL) {
-        free(h);
+        htp_free(h);
         return HTP_ERROR;
     }
 
     h->value = copy_or_wrap_mem(value, value_len, alloc);
     if (h->value == NULL) {
         bstr_free(h->name);
-        free(h);
+        htp_free(h);
         return HTP_ERROR;
     }
 
     if (htp_table_add(tx->request_headers, h->name, h) != HTP_OK) {
         bstr_free(h->name);
         bstr_free(h->value);
-        free(h);
+        htp_free(h);
         return HTP_ERROR;
     }
 
@@ -442,7 +442,7 @@ static htp_status_t htp_tx_process_request_headers(htp_tx_t *tx) {
         if (htp_tx_req_has_body(tx)) {
             // Prepare to treat PUT request body as a file.
             
-            tx->connp->put_file = calloc(1, sizeof (htp_file_t));
+            tx->connp->put_file = htp_calloc(1, sizeof (htp_file_t));
             if (tx->connp->put_file == NULL) return HTP_ERROR;
 
             tx->connp->put_file->fd = -1;
@@ -596,7 +596,7 @@ htp_status_t htp_tx_req_set_headers_clear(htp_tx_t *tx) {
         h = htp_table_get_index(tx->request_headers, i, NULL);
         bstr_free(h->name);
         bstr_free(h->value);
-        free(h);
+        htp_free(h);
     }
 
     htp_table_destroy(tx->request_headers);
@@ -699,26 +699,26 @@ htp_status_t htp_tx_res_set_header(htp_tx_t *tx, const char *name, size_t name_l
     if ((tx == NULL) || (name == NULL) || (value == NULL)) return HTP_ERROR;
 
 
-    htp_header_t *h = calloc(1, sizeof (htp_header_t));
+    htp_header_t *h = htp_calloc(1, sizeof (htp_header_t));
     if (h == NULL) return HTP_ERROR;
 
     h->name = copy_or_wrap_mem(name, name_len, alloc);
     if (h->name == NULL) {
-        free(h);
+        htp_free(h);
         return HTP_ERROR;
     }
 
     h->value = copy_or_wrap_mem(value, value_len, alloc);
     if (h->value == NULL) {
         bstr_free(h->name);
-        free(h);
+        htp_free(h);
         return HTP_ERROR;
     }
 
     if (htp_table_add(tx->response_headers, h->name, h) != HTP_OK) {
         bstr_free(h->name);
         bstr_free(h->value);
-        free(h);
+        htp_free(h);
         return HTP_ERROR;
     }
 
@@ -733,7 +733,7 @@ htp_status_t htp_tx_res_set_headers_clear(htp_tx_t *tx) {
         h = htp_table_get_index(tx->response_headers, i, NULL);
         bstr_free(h->name);
         bstr_free(h->value);
-        free(h);
+        htp_free(h);
     }
 
     htp_table_destroy(tx->response_headers);
@@ -838,7 +838,7 @@ htp_status_t htp_tx_state_request_complete_partial(htp_tx_t *tx) {
     // Clean-up.
     if (tx->connp->put_file != NULL) {
         bstr_free(tx->connp->put_file->filename);
-        free(tx->connp->put_file);
+        htp_free(tx->connp->put_file);
         tx->connp->put_file = NULL;
     }
 

--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -137,7 +137,7 @@ void htp_tx_destroy_incomplete(htp_tx_t *tx) {
             h = htp_table_get_index(tx->request_headers, i, NULL);
             bstr_free(h->name);
             bstr_free(h->value);
-            htp_free(h);
+            htp_free(h, sizeof(htp_header_t));
         }
 
         htp_table_destroy(tx->request_headers);
@@ -156,7 +156,7 @@ void htp_tx_destroy_incomplete(htp_tx_t *tx) {
         param = htp_table_get_index(tx->request_params, i, NULL);
         bstr_free(param->name);
         bstr_free(param->value);
-        htp_free(param);
+        htp_free(param, sizeof(htp_param_t));
     }
 
     htp_table_destroy(tx->request_params);
@@ -190,7 +190,7 @@ void htp_tx_destroy_incomplete(htp_tx_t *tx) {
             h = htp_table_get_index(tx->response_headers, i, NULL);
             bstr_free(h->name);
             bstr_free(h->value);
-            htp_free(h);
+            htp_free(h, sizeof(htp_header_t));
         }
 
         htp_table_destroy(tx->response_headers);
@@ -201,7 +201,7 @@ void htp_tx_destroy_incomplete(htp_tx_t *tx) {
         htp_config_destroy(tx->cfg);
     }
 
-    htp_free(tx);
+    htp_free(tx, sizeof(*tx));
 }
 
 int htp_tx_get_is_config_shared(const htp_tx_t *tx) {
@@ -282,21 +282,21 @@ htp_status_t htp_tx_req_set_header(htp_tx_t *tx, const char *name, size_t name_l
 
     h->name = copy_or_wrap_mem(name, name_len, alloc);
     if (h->name == NULL) {
-        htp_free(h);
+        htp_free(h, sizeof (htp_header_t));
         return HTP_ERROR;
     }
 
     h->value = copy_or_wrap_mem(value, value_len, alloc);
     if (h->value == NULL) {
         bstr_free(h->name);
-        htp_free(h);
+        htp_free(h, sizeof (htp_header_t));
         return HTP_ERROR;
     }
 
     if (htp_table_add(tx->request_headers, h->name, h) != HTP_OK) {
         bstr_free(h->name);
         bstr_free(h->value);
-        htp_free(h);
+        htp_free(h, sizeof (htp_header_t));
         return HTP_ERROR;
     }
 
@@ -596,7 +596,7 @@ htp_status_t htp_tx_req_set_headers_clear(htp_tx_t *tx) {
         h = htp_table_get_index(tx->request_headers, i, NULL);
         bstr_free(h->name);
         bstr_free(h->value);
-        htp_free(h);
+        htp_free(h, sizeof (htp_header_t));
     }
 
     htp_table_destroy(tx->request_headers);
@@ -704,21 +704,21 @@ htp_status_t htp_tx_res_set_header(htp_tx_t *tx, const char *name, size_t name_l
 
     h->name = copy_or_wrap_mem(name, name_len, alloc);
     if (h->name == NULL) {
-        htp_free(h);
+        htp_free(h, sizeof (htp_header_t));
         return HTP_ERROR;
     }
 
     h->value = copy_or_wrap_mem(value, value_len, alloc);
     if (h->value == NULL) {
         bstr_free(h->name);
-        htp_free(h);
+        htp_free(h, sizeof (htp_header_t));
         return HTP_ERROR;
     }
 
     if (htp_table_add(tx->response_headers, h->name, h) != HTP_OK) {
         bstr_free(h->name);
         bstr_free(h->value);
-        htp_free(h);
+        htp_free(h, sizeof (htp_header_t));
         return HTP_ERROR;
     }
 
@@ -733,7 +733,7 @@ htp_status_t htp_tx_res_set_headers_clear(htp_tx_t *tx) {
         h = htp_table_get_index(tx->response_headers, i, NULL);
         bstr_free(h->name);
         bstr_free(h->value);
-        htp_free(h);
+        htp_free(h, sizeof (htp_header_t));
     }
 
     htp_table_destroy(tx->response_headers);
@@ -838,7 +838,7 @@ htp_status_t htp_tx_state_request_complete_partial(htp_tx_t *tx) {
     // Clean-up.
     if (tx->connp->put_file != NULL) {
         bstr_free(tx->connp->put_file->filename);
-        htp_free(tx->connp->put_file);
+        htp_free(tx->connp->put_file, sizeof(*(tx->connp->put_file)));
         tx->connp->put_file = NULL;
     }
 

--- a/htp/htp_transcoder.c
+++ b/htp/htp_transcoder.c
@@ -145,7 +145,7 @@ int htp_transcode_bstr(iconv_t cd, bstr *input, bstr **output) {
 
     bstr_builder_t *bb = NULL;
 
-    size_t buflen = 10;
+    const size_t buflen = 10;
     unsigned char *buf = malloc(buflen);
     if (buf == NULL) {
         return HTP_ERROR;

--- a/htp/htp_transcoder.c
+++ b/htp/htp_transcoder.c
@@ -166,7 +166,7 @@ int htp_transcode_bstr(iconv_t cd, bstr *input, bstr **output) {
                 if (bb == NULL) {
                     bb = bstr_builder_create();
                     if (bb == NULL) {
-                        htp_free(buf);
+                        htp_free(buf, buflen);
                         return HTP_ERROR;
                     }
                 }
@@ -182,7 +182,7 @@ int htp_transcode_bstr(iconv_t cd, bstr *input, bstr **output) {
             } else {
                 // Error
                 if (bb != NULL) bstr_builder_destroy(bb);
-                htp_free(buf);
+                htp_free(buf, buflen);
                 return HTP_ERROR;
             }
         }
@@ -193,18 +193,18 @@ int htp_transcode_bstr(iconv_t cd, bstr *input, bstr **output) {
         *output = bstr_builder_to_str(bb);
         bstr_builder_destroy(bb);
         if (*output == NULL) {
-            htp_free(buf);
+            htp_free(buf, buflen);
             return HTP_ERROR;
         }
     } else {
         *output = bstr_dup_mem(buf, buflen - outleft);
         if (*output == NULL) {
-            htp_free(buf);
+            htp_free(buf, buflen);
             return HTP_ERROR;
         }
     }
     
-    htp_free(buf);
+    htp_free(buf, buflen);
 
     return HTP_OK;
 }

--- a/htp/htp_transcoder.c
+++ b/htp/htp_transcoder.c
@@ -146,7 +146,7 @@ int htp_transcode_bstr(iconv_t cd, bstr *input, bstr **output) {
     bstr_builder_t *bb = NULL;
 
     const size_t buflen = 10;
-    unsigned char *buf = malloc(buflen);
+    unsigned char *buf = htp_malloc(buflen);
     if (buf == NULL) {
         return HTP_ERROR;
     }
@@ -166,7 +166,7 @@ int htp_transcode_bstr(iconv_t cd, bstr *input, bstr **output) {
                 if (bb == NULL) {
                     bb = bstr_builder_create();
                     if (bb == NULL) {
-                        free(buf);
+                        htp_free(buf);
                         return HTP_ERROR;
                     }
                 }
@@ -182,7 +182,7 @@ int htp_transcode_bstr(iconv_t cd, bstr *input, bstr **output) {
             } else {
                 // Error
                 if (bb != NULL) bstr_builder_destroy(bb);
-                free(buf);
+                htp_free(buf);
                 return HTP_ERROR;
             }
         }
@@ -193,18 +193,18 @@ int htp_transcode_bstr(iconv_t cd, bstr *input, bstr **output) {
         *output = bstr_builder_to_str(bb);
         bstr_builder_destroy(bb);
         if (*output == NULL) {
-            free(buf);
+            htp_free(buf);
             return HTP_ERROR;
         }
     } else {
         *output = bstr_dup_mem(buf, buflen - outleft);
         if (*output == NULL) {
-            free(buf);
+            htp_free(buf);
             return HTP_ERROR;
         }
     }
     
-    free(buf);
+    htp_free(buf);
 
     return HTP_OK;
 }

--- a/htp/htp_urlencoded.c
+++ b/htp/htp_urlencoded.c
@@ -172,21 +172,21 @@ static void htp_urlenp_add_field_piece(htp_urlenp_t *urlenp, const unsigned char
  * @return New parser, or NULL on memory allocation failure.
  */
 htp_urlenp_t *htp_urlenp_create(htp_tx_t *tx) {
-    htp_urlenp_t *urlenp = calloc(1, sizeof (htp_urlenp_t));
+    htp_urlenp_t *urlenp = htp_calloc(1, sizeof (htp_urlenp_t));
     if (urlenp == NULL) return NULL;
 
     urlenp->tx = tx;
 
     urlenp->params = htp_table_create(HTP_URLENP_DEFAULT_PARAMS_SIZE);
     if (urlenp->params == NULL) {
-        free(urlenp);
+        htp_free(urlenp);
         return NULL;
     }
 
     urlenp->_bb = bstr_builder_create();
     if (urlenp->_bb == NULL) {
         htp_table_destroy(urlenp->params);
-        free(urlenp);
+        htp_free(urlenp);
         return NULL;
     }
 
@@ -222,7 +222,7 @@ void htp_urlenp_destroy(htp_urlenp_t *urlenp) {
         htp_table_destroy(urlenp->params);
     }
 
-    free(urlenp);
+    htp_free(urlenp);
 }
 
 /**

--- a/htp/htp_urlencoded.c
+++ b/htp/htp_urlencoded.c
@@ -179,14 +179,14 @@ htp_urlenp_t *htp_urlenp_create(htp_tx_t *tx) {
 
     urlenp->params = htp_table_create(HTP_URLENP_DEFAULT_PARAMS_SIZE);
     if (urlenp->params == NULL) {
-        htp_free(urlenp);
+        htp_free(urlenp, sizeof(htp_urlenp_t));
         return NULL;
     }
 
     urlenp->_bb = bstr_builder_create();
     if (urlenp->_bb == NULL) {
         htp_table_destroy(urlenp->params);
-        htp_free(urlenp);
+        htp_free(urlenp, sizeof(htp_urlenp_t));
         return NULL;
     }
 
@@ -222,7 +222,7 @@ void htp_urlenp_destroy(htp_urlenp_t *urlenp) {
         htp_table_destroy(urlenp->params);
     }
 
-    htp_free(urlenp);
+    htp_free(urlenp, sizeof(htp_urlenp_t));
 }
 
 /**

--- a/htp/htp_util.c
+++ b/htp/htp_util.c
@@ -72,7 +72,10 @@ void htp_free(void *ptr, size_t size) {
 }
 
 char *htp_strdup(const char *s) {
-    return strdup(s);
+    char *ptr = strdup(s);
+    if (ptr != NULL)
+        __sync_add_and_fetch(&memuse, strlen(ptr));
+    return ptr;
 }
 
 /**

--- a/htp/htp_util.c
+++ b/htp/htp_util.c
@@ -46,7 +46,7 @@ void *htp_calloc(size_t nmemb, size_t size) {
     return calloc(nmemb, size);
 }
 
-void *htp_realloc(void *ptr, size_t size) {
+void *htp_realloc(void *ptr, size_t size, size_t oldsize) {
     return realloc(ptr, size);
 }
 

--- a/htp/htp_util.c
+++ b/htp/htp_util.c
@@ -71,6 +71,10 @@ void htp_free(void *ptr, size_t size) {
     free(ptr);
 }
 
+char *htp_strdup(const char *s) {
+    return strdup(s);
+}
+
 /**
  * Is character a linear white space character?
  *
@@ -402,7 +406,7 @@ void htp_log(htp_connp_t *connp, const char *file, int line, enum htp_log_level_
     log->line = line;
     log->level = level;
     log->code = code;
-    log->msg = strdup(buf);
+    log->msg = htp_strdup(buf);
 
     htp_list_add(connp->conn->messages, log);
 

--- a/htp/htp_util.c
+++ b/htp/htp_util.c
@@ -38,6 +38,22 @@
 
 #include "htp_private.h"
 
+void *htp_malloc(size_t size) {
+    return malloc(size);
+}
+
+void *htp_calloc(size_t nmemb, size_t size) {
+    return calloc(nmemb, size);
+}
+
+void *htp_realloc(void *ptr, size_t size) {
+    return realloc(ptr, size);
+}
+
+void htp_free(void *ptr) {
+    free(ptr);
+}
+
 /**
  * Is character a linear white space character?
  *
@@ -361,7 +377,7 @@ void htp_log(htp_connp_t *connp, const char *file, int line, enum htp_log_level_
 
     // Create a new log entry.
 
-    htp_log_t *log = calloc(1, sizeof (htp_log_t));
+    htp_log_t *log = htp_calloc(1, sizeof (htp_log_t));
     if (log == NULL) return;
 
     log->connp = connp;
@@ -638,7 +654,7 @@ int htp_parse_uri(bstr *input, htp_uri_t **uri) {
     // Allow a htp_uri_t structure to be provided on input,
     // but allocate a new one if the structure is NULL.
     if (*uri == NULL) {
-        *uri = calloc(1, sizeof (htp_uri_t));
+        *uri = htp_calloc(1, sizeof (htp_uri_t));
         if (*uri == NULL) return HTP_ERROR;
     }
 
@@ -2556,11 +2572,11 @@ void htp_uri_free(htp_uri_t *uri) {
     bstr_free(uri->query);
     bstr_free(uri->fragment);
 
-    free(uri);
+    htp_free(uri);
 }
 
 htp_uri_t *htp_uri_alloc() {
-    htp_uri_t *u = calloc(1, sizeof (htp_uri_t));
+    htp_uri_t *u = htp_calloc(1, sizeof (htp_uri_t));
     if (u == NULL) return NULL;
 
     u->port_number = -1;

--- a/htp/htp_util.c
+++ b/htp/htp_util.c
@@ -50,7 +50,7 @@ void *htp_realloc(void *ptr, size_t size, size_t oldsize) {
     return realloc(ptr, size);
 }
 
-void htp_free(void *ptr) {
+void htp_free(void *ptr, size_t size) {
     free(ptr);
 }
 
@@ -2572,7 +2572,7 @@ void htp_uri_free(htp_uri_t *uri) {
     bstr_free(uri->query);
     bstr_free(uri->fragment);
 
-    htp_free(uri);
+    htp_free(uri, sizeof(htp_uri_t));
 }
 
 htp_uri_t *htp_uri_alloc() {


### PR DESCRIPTION
**Not for merge.**

In my quest to find where Suricata spends it's memory I've created this branch to track libhtp's memory allocations and frees. What it does is create wrapper functions for malloc, calloc and friends: htp_malloc, htp_calloc, etc.

Each of those then updates a global counter (using gcc atomics to be thread safe), which indicates the current amount of memory in use by libhtp.

A simple new function htp_memory_get_memuse() exposes this value to the application.

To make this work, all calls to 'htp_free' and 'htp_realloc' had to be changed to take the current size of the memory as an argument.

I think the wrappers themselves make sense, although the size arguments to free and realloc are a bit painful and easy to mess up. The counter implementation is probably a problem. Maybe we could have a callback or a set of callbacks that is called for each allocation. The memuse counter could then move into the application:

<pre>
void *htp_malloc(size_t size) {
    void *ptr = malloc(size);
    if (ptr && htp_malloc_callback)
        htp_malloc_callback(size);
    return ptr;
}
</pre>

My callback (in Suricata) would then be:

<pre>
void HtpMallocUpdate(size_t size) {
    SC_ATOMIC_ADD(libhtp_memuse, size);
}
</pre>

Or we could to a more generic update callback, that pushes a signed int so both memory use grow and shrink operations call the same callback.
