### PR TITLE
In htp_log, set the htp_log_t::tx field

### DIFF
--- a/htp/htp_util.c
+++ b/htp/htp_util.c
@@ -370,6 +370,7 @@ void htp_log(htp_connp_t *connp, const char *file, int line, enum htp_log_level_
     log->level = level;
     log->code = code;
     log->msg = strdup(buf);
+    log->tx = connp->in_tx ? connp->in_tx : connp->out_tx;
 
     htp_list_add(connp->conn->messages, log);
 


### PR DESCRIPTION
The htp_log_t structure has a pointer to the transaction in by which
the message was raised. However, the field is never set.

This patch sets it based on either the htp_connp_t::in_tx or the
htp_connp_t::out_tx pointers. The former has preference over the
latter.
