### PR TITLE
Fix compilation warnings/errors on 32bit

### DIFF
--- a/htp/htp_core.h
+++ b/htp/htp_core.h
@@ -192,43 +192,43 @@ enum htp_file_source_t {
 // that contains the header. Both uses are useful.
 
 // Connection flags are 8 bits wide.
-#define HTP_CONN_PIPELINED                 0x000000001
-#define HTP_CONN_HTTP_0_9_EXTRA            0x000000002
+#define HTP_CONN_PIPELINED                 0x000000001ULL
+#define HTP_CONN_HTTP_0_9_EXTRA            0x000000002ULL
 
 // All other flags are 64 bits wide.
-#define HTP_FIELD_UNPARSEABLE              0x000000004
-#define HTP_FIELD_INVALID                  0x000000008
-#define HTP_FIELD_FOLDED                   0x000000010
-#define HTP_FIELD_REPEATED                 0x000000020
-#define HTP_FIELD_LONG                     0x000000040
-#define HTP_FIELD_RAW_NUL                  0x000000080
-#define HTP_REQUEST_SMUGGLING              0x000000100
-#define HTP_INVALID_FOLDING                0x000000200
-#define HTP_REQUEST_INVALID_T_E            0x000000400
-#define HTP_MULTI_PACKET_HEAD              0x000000800
-#define HTP_HOST_MISSING                   0x000001000
-#define HTP_HOST_AMBIGUOUS                 0x000002000
-#define HTP_PATH_ENCODED_NUL               0x000004000
-#define HTP_PATH_RAW_NUL                   0x000008000
-#define HTP_PATH_INVALID_ENCODING          0x000010000
-#define HTP_PATH_INVALID                   0x000020000
-#define HTP_PATH_OVERLONG_U                0x000040000
-#define HTP_PATH_ENCODED_SEPARATOR         0x000080000
-#define HTP_PATH_UTF8_VALID                0x000100000 /* At least one valid UTF-8 character and no invalid ones. */
-#define HTP_PATH_UTF8_INVALID              0x000200000
-#define HTP_PATH_UTF8_OVERLONG             0x000400000
-#define HTP_PATH_HALF_FULL_RANGE           0x000800000 /* Range U+FF00 - U+FFEF detected. */
-#define HTP_STATUS_LINE_INVALID            0x001000000
-#define HTP_HOSTU_INVALID                  0x002000000 /* Host in the URI. */
-#define HTP_HOSTH_INVALID                  0x004000000 /* Host in the Host header. */
-#define HTP_URLEN_ENCODED_NUL              0x008000000
-#define HTP_URLEN_INVALID_ENCODING         0x010000000
-#define HTP_URLEN_OVERLONG_U               0x020000000
-#define HTP_URLEN_HALF_FULL_RANGE          0x040000000 /* Range U+FF00 - U+FFEF detected. */
-#define HTP_URLEN_RAW_NUL                  0x080000000
-#define HTP_REQUEST_INVALID                0x100000000
-#define HTP_REQUEST_INVALID_C_L            0x200000000
-#define HTP_AUTH_INVALID                   0x400000000
+#define HTP_FIELD_UNPARSEABLE              0x000000004ULL
+#define HTP_FIELD_INVALID                  0x000000008ULL
+#define HTP_FIELD_FOLDED                   0x000000010ULL
+#define HTP_FIELD_REPEATED                 0x000000020ULL
+#define HTP_FIELD_LONG                     0x000000040ULL
+#define HTP_FIELD_RAW_NUL                  0x000000080ULL
+#define HTP_REQUEST_SMUGGLING              0x000000100ULL
+#define HTP_INVALID_FOLDING                0x000000200ULL
+#define HTP_REQUEST_INVALID_T_E            0x000000400ULL
+#define HTP_MULTI_PACKET_HEAD              0x000000800ULL
+#define HTP_HOST_MISSING                   0x000001000ULL
+#define HTP_HOST_AMBIGUOUS                 0x000002000ULL
+#define HTP_PATH_ENCODED_NUL               0x000004000ULL
+#define HTP_PATH_RAW_NUL                   0x000008000ULL
+#define HTP_PATH_INVALID_ENCODING          0x000010000ULL
+#define HTP_PATH_INVALID                   0x000020000ULL
+#define HTP_PATH_OVERLONG_U                0x000040000ULL
+#define HTP_PATH_ENCODED_SEPARATOR         0x000080000ULL
+#define HTP_PATH_UTF8_VALID                0x000100000ULL /* At least one valid UTF-8 character and no invalid ones. */
+#define HTP_PATH_UTF8_INVALID              0x000200000ULL
+#define HTP_PATH_UTF8_OVERLONG             0x000400000ULL
+#define HTP_PATH_HALF_FULL_RANGE           0x000800000ULL /* Range U+FF00 - U+FFEF detected. */
+#define HTP_STATUS_LINE_INVALID            0x001000000ULL
+#define HTP_HOSTU_INVALID                  0x002000000ULL /* Host in the URI. */
+#define HTP_HOSTH_INVALID                  0x004000000ULL /* Host in the Host header. */
+#define HTP_URLEN_ENCODED_NUL              0x008000000ULL
+#define HTP_URLEN_INVALID_ENCODING         0x010000000ULL
+#define HTP_URLEN_OVERLONG_U               0x020000000ULL
+#define HTP_URLEN_HALF_FULL_RANGE          0x040000000ULL /* Range U+FF00 - U+FFEF detected. */
+#define HTP_URLEN_RAW_NUL                  0x080000000ULL
+#define HTP_REQUEST_INVALID                0x100000000ULL
+#define HTP_REQUEST_INVALID_C_L            0x200000000ULL
+#define HTP_AUTH_INVALID                   0x400000000ULL
 
 #define HTP_HOST_INVALID ( HTP_HOSTU_INVALID | HTP_HOSTH_INVALID )
 

--- a/test/test_bstr.cpp
+++ b/test/test_bstr.cpp
@@ -492,7 +492,7 @@ TEST(BstrTest, ToPint) {
 
     EXPECT_EQ(-1, bstr_util_mem_to_pint("abc", 3, 10, &lastlen));
     EXPECT_EQ(-2, bstr_util_mem_to_pint("fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", 40, 16, &lastlen));
-    EXPECT_EQ(0x7fffffffffffffffL, bstr_util_mem_to_pint("7fffffffffffffff", 16, 16, &lastlen));
+    EXPECT_EQ(0x7fffffffffffffffLL, bstr_util_mem_to_pint("7fffffffffffffff", 16, 16, &lastlen));
     EXPECT_EQ(-2, bstr_util_mem_to_pint("9223372036854775808", 19, 10, &lastlen));
     EXPECT_EQ(0xabc, bstr_util_mem_to_pint("abc", 3, 16, &lastlen));
     EXPECT_EQ(4, lastlen);


### PR DESCRIPTION
On 32bit OpenBSD 5.4 make distcheck failed with:

../../../libhtp/test/test_bstr.cpp:495: error: integer constant is too large for 'long' type
../../../libhtp/test/test_bstr.cpp:495: error: integer constant is too large for 'long' type
../../../libhtp/test/test_main.cpp:929: error: integer constant is too large for 'long' type
../../../libhtp/test/test_main.cpp:930: error: integer constant is too large for 'long' type
../../../libhtp/test/test_main.cpp:958: error: integer constant is too large for 'long' type
../../../libhtp/test/test_main.cpp:1052: error: integer constant is too large for 'long' type
../../../libhtp/test/test_main.cpp:1070: error: integer constant is too large for 'long' type
../../../libhtp/test/test_main.cpp:1088: error: integer constant is too large for 'long' type
../../../libhtp/test/test_main.cpp:1787: error: integer constant is too large for 'long' type

This patch marks all the flags for the 64bit flags fields as ULL,
and fixes one test manually.
