### PR TITLE
test/Makefile.am: Fix issue with --disable-static.

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,4 +1,4 @@
-LDADD = $(top_builddir)/htp/.libs/libhtp.a -lz @LIBICONV@ 
+LDADD = $(top_builddir)/htp/libhtp.la -lz @LIBICONV@ 
 AM_CFLAGS = -g -std=gnu99
 AM_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir)/htp -Wno-write-strings -DGTEST_USE_OWN_TR1_TUPLE=1
 AUTOMAKE_OPTIONS = subdir-objects


### PR DESCRIPTION
Simple fix to `test/Makefile.am` which allows `make check` to succeed if `--disable-static` is passed to `configure`.  `--disable-static` is nice as it gives (on my machine) ~40% faster compile times by not double-compiling every object file.
