### PR TITLE
Fix missing files in distribution target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@ ACLOCAL_AMFLAGS = -I m4
 SUBDIRS = htp test docs
 
 DIST_SUBDIRS = htp test docs
-EXTRA_DIST = LICENSE NOTICE docs/doxygen.conf docs/QUICK_START 
+EXTRA_DIST = LICENSE NOTICE docs/doxygen.conf docs/QUICK_START VERSION get-version.sh
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = htp.pc


### PR DESCRIPTION
When running autoreconf -f -i on a distributed tarball, the configuration fails with the following error:
    autoreconf -f -i
sh: 1: ./get-version.sh: not found
configure.ac:7: error: AC_INIT should be called with package and version arguments
/usr/share/aclocal-1.14/init.m4:29: AM_INIT_AUTOMAKE is expanded from...
configure.ac:7: the top level

Files VERSION and get-version.sh are required to run autoreconf, on the
sources from a 'make dist' tarball.
Add them to the EXTRA_DIST target.
