### PR TITLE
Fix double Content-Length issue.

### DIFF
--- a/test/files/88-response-multiple-cl-mismatch.t
+++ b/test/files/88-response-multiple-cl-mismatch.t
@@ -1,0 +1,14 @@
+>>>
+GET / HTTP/1.0
+
+
+<<<
+HTTP/1.0 200 OK
+Date: Mon, 31 Aug 2009 20:25:50 GMT
+Server: Apache
+Connection: close
+Content-Type: text/html
+Content-Length: 11
+Content-Length: 12
+
+Hello World!

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1646,7 +1646,29 @@ TEST_F(ConnectionParsing, ResponseContainsTeAndCl) {
 
 TEST_F(ConnectionParsing, ResponseMultipleCl) {
     int rc = test_run(home, "74-response-multiple-cl.t", cfg, &connp);
-    ASSERT_LT(rc, 0); // Expect error.
+    ASSERT_GE(rc, 0);
+
+    ASSERT_EQ(1, htp_list_size(connp->conn->transactions));
+
+    htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
+    ASSERT_TRUE(tx != NULL);
+
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+    ASSERT_EQ(HTP_RESPONSE_COMPLETE, tx->response_progress);
+
+    ASSERT_TRUE(tx->flags & HTP_REQUEST_SMUGGLING);
+
+    htp_header_t *h = (htp_header_t *)htp_table_get_c(tx->response_headers, "Content-Length");
+    ASSERT_TRUE(h != NULL);
+    ASSERT_TRUE(h->value != NULL);
+    ASSERT_TRUE(h->flags & HTP_FIELD_REPEATED);
+
+    ASSERT_EQ(0, bstr_cmp_c(h->value, "12"));
+}
+
+TEST_F(ConnectionParsing, ResponseMultipleClMismatch) {
+    int rc = test_run(home, "88-response-multiple-cl-mismatch.t", cfg, &connp);
+    ASSERT_LT(rc, 0); // Expect error
 
     ASSERT_EQ(1, htp_list_size(connp->conn->transactions));
 
@@ -1655,8 +1677,6 @@ TEST_F(ConnectionParsing, ResponseMultipleCl) {
 
     ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
     ASSERT_EQ(HTP_RESPONSE_HEADERS, tx->response_progress);
-
-    ASSERT_TRUE(tx->flags & HTP_REQUEST_SMUGGLING);
 }
 
 TEST_F(ConnectionParsing, ResponseInvalidCl) {


### PR DESCRIPTION
I've seen situtations where a server will send duplicate Content-Length
headers. I've tested this with Chrome and it will ignore the second header
if the value is the same. If the value is different Chrome throws an error.

This causes a discrepency between how a browser will handle the content
and how libhtp does. To address this I've added support for checking for
duplicate Content-Length headers and ignoring subsequent ones if the value
is the same as the first one.

Also, fix up the test (74-response-multiple-cl) now that this is not an
error condition. Also, add a test where there is a value mismatch which
is a failure.
