### PR TITLE
Initial travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: c
+compiler:
+  - gcc
+  - clang
+# Change this to your needs
+script: sh autogen.sh && ./configure && make && make check
+before_install:
+  - sudo apt-get update -qq
+  - sudo apt-get install -y build-essential autoconf automake libtool zlib1g zlib1g-dev make 
+


### PR DESCRIPTION
Enable basic travis-ci integration. This will allow you to enable basic build tests on both commits and pull requests. To complete this, setup your account here: http://docs.travis-ci.com/user/getting-started/

Example from how we use it in Suricata: https://travis-ci.org/inliniac/suricata
