### PR TITLE
Make a case-insensitive comparision for the pattern "chunked" for "Transfer-Encoding"

### DIFF
--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -555,7 +555,7 @@ htp_status_t htp_connp_RES_BODY_DETERMINE(htp_connp_t *connp) {
         // 2. If a Transfer-Encoding header field (section 14.40) is present and
         //   indicates that the "chunked" transfer coding has been applied, then
         //   the length is defined by the chunked encoding (section 3.6).
-        if ((te != NULL) && (bstr_cmp_c(te->value, "chunked") == 0)) {
+        if ((te != NULL) && (bstr_cmp_c_nocase(te->value, "chunked") == 0)) {
             // If the T-E header is present we are going to use it.
             connp->out_tx->response_transfer_coding = HTP_CODING_CHUNKED;
 

--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -371,7 +371,7 @@ static htp_status_t htp_tx_process_request_headers(htp_tx_t *tx) {
         //      (2.2.22 on Ubuntu 12.04 LTS) instead errors out with "Unknown Transfer-Encoding: identity".
         //      And it behaves strangely, too, sending a 501 and proceeding to process the request
         //      (e.g., PHP is run), but without the body. It then closes the connection.
-        if (bstr_cmp_c(te->value, "chunked") != 0) {
+        if (bstr_cmp_c_nocase(te->value, "chunked") != 0) {
             // Invalid T-E header value.
             tx->request_transfer_coding = HTP_CODING_INVALID;
             tx->flags |= HTP_REQUEST_INVALID_T_E;


### PR DESCRIPTION
While verifying the value of the "Transfer-Encoding" header, libhtp does a
case-sensitive comparison for the value "chunked", thus pushing out
case-sensitive values such as "Chunked".

Convert the case-sensitive comparison to a case-insensitive one by using
bstr_cmp_c_nocase(), instead of the currently used bstr_cmp_c().
