### PR TITLE
[rfc] Request line leading space handling

### DIFF
--- a/htp/htp_config.c
+++ b/htp/htp_config.c
@@ -559,6 +559,7 @@ int htp_config_set_server_personality(htp_cfg_t *cfg, enum htp_server_personalit
             htp_config_set_convert_lowercase(cfg, HTP_DECODER_URL_PATH, 1);
             htp_config_set_utf8_convert_bestfit(cfg, HTP_DECODER_URL_PATH, 1);
             htp_config_set_u_encoding_decode(cfg, HTP_DECODER_URL_PATH, 1);
+            htp_config_set_requestline_leading_whitespace_unwanted(cfg, HTP_DECODER_DEFAULTS, HTP_UNWANTED_IGNORE);
             break;
 
         case HTP_SERVER_APACHE_2:
@@ -575,6 +576,7 @@ int htp_config_set_server_personality(htp_cfg_t *cfg, enum htp_server_personalit
             htp_config_set_url_encoding_invalid_handling(cfg, HTP_DECODER_URL_PATH, HTP_URL_DECODE_PRESERVE_PERCENT);
             htp_config_set_url_encoding_invalid_unwanted(cfg, HTP_DECODER_URL_PATH, HTP_UNWANTED_400);
             htp_config_set_control_chars_unwanted(cfg, HTP_DECODER_URL_PATH, HTP_UNWANTED_IGNORE);
+            htp_config_set_requestline_leading_whitespace_unwanted(cfg, HTP_DECODER_DEFAULTS, HTP_UNWANTED_400);
             break;
 
         case HTP_SERVER_IIS_5_1:
@@ -590,6 +592,7 @@ int htp_config_set_server_personality(htp_cfg_t *cfg, enum htp_server_personalit
 
             htp_config_set_url_encoding_invalid_handling(cfg, HTP_DECODER_URL_PATH, HTP_URL_DECODE_PRESERVE_PERCENT);
             htp_config_set_control_chars_unwanted(cfg, HTP_DECODER_URL_PATH, HTP_UNWANTED_IGNORE);
+            htp_config_set_requestline_leading_whitespace_unwanted(cfg, HTP_DECODER_DEFAULTS, HTP_UNWANTED_IGNORE);
             break;
 
         case HTP_SERVER_IIS_6_0:
@@ -606,6 +609,7 @@ int htp_config_set_server_personality(htp_cfg_t *cfg, enum htp_server_personalit
             htp_config_set_url_encoding_invalid_handling(cfg, HTP_DECODER_URL_PATH, HTP_URL_DECODE_PRESERVE_PERCENT);
             htp_config_set_u_encoding_unwanted(cfg, HTP_DECODER_URL_PATH, HTP_UNWANTED_400);
             htp_config_set_control_chars_unwanted(cfg, HTP_DECODER_URL_PATH, HTP_UNWANTED_400);
+            htp_config_set_requestline_leading_whitespace_unwanted(cfg, HTP_DECODER_DEFAULTS, HTP_UNWANTED_IGNORE);
             break;
 
         case HTP_SERVER_IIS_7_0:
@@ -623,6 +627,7 @@ int htp_config_set_server_personality(htp_cfg_t *cfg, enum htp_server_personalit
             htp_config_set_url_encoding_invalid_handling(cfg, HTP_DECODER_URL_PATH, HTP_URL_DECODE_PRESERVE_PERCENT);
             htp_config_set_url_encoding_invalid_unwanted(cfg, HTP_DECODER_URL_PATH, HTP_UNWANTED_400);
             htp_config_set_control_chars_unwanted(cfg, HTP_DECODER_URL_PATH, HTP_UNWANTED_400);
+            htp_config_set_requestline_leading_whitespace_unwanted(cfg, HTP_DECODER_DEFAULTS, HTP_UNWANTED_IGNORE);
             break;
 
         default:
@@ -880,6 +885,18 @@ void htp_config_set_utf8_invalid_unwanted(htp_cfg_t *cfg, enum htp_decoder_ctx_t
     if (ctx == HTP_DECODER_DEFAULTS) {
         for (size_t i = 0; i < HTP_DECODER_CONTEXTS_MAX; i++) {
             cfg->decoder_cfgs[i].utf8_invalid_unwanted = unwanted;
+        }
+    }
+}
+
+void htp_config_set_requestline_leading_whitespace_unwanted(htp_cfg_t *cfg, enum htp_decoder_ctx_t ctx, enum htp_unwanted_t unwanted) {
+    if (ctx >= HTP_DECODER_CONTEXTS_MAX) return;
+
+    cfg->decoder_cfgs[ctx].requestline_leading_whitespace_unwanted = unwanted;
+
+    if (ctx == HTP_DECODER_DEFAULTS) {
+        for (size_t i = 0; i < HTP_DECODER_CONTEXTS_MAX; i++) {
+            cfg->decoder_cfgs[i].requestline_leading_whitespace_unwanted = unwanted;
         }
     }
 }

--- a/htp/htp_config.h
+++ b/htp/htp_config.h
@@ -638,6 +638,14 @@ void htp_config_set_utf8_convert_bestfit(htp_cfg_t *cfg, enum htp_decoder_ctx_t 
  */
 void htp_config_set_utf8_invalid_unwanted(htp_cfg_t *cfg, enum htp_decoder_ctx_t ctx, enum htp_unwanted_t unwanted);
 
+/**
+ * Configures how the server reacts to leading whitespace on the request line.
+ *
+ * @param[in] cfg
+ * @param[in] ctx
+ * @param[in] unwanted
+ */
+void htp_config_set_requestline_leading_whitespace_unwanted(htp_cfg_t *cfg, enum htp_decoder_ctx_t ctx, enum htp_unwanted_t unwanted);
 
 #ifdef	__cplusplus
 }

--- a/htp/htp_config_private.h
+++ b/htp/htp_config_private.h
@@ -117,6 +117,12 @@ typedef struct htp_decoder_cfg_t {
 
     /** The replacement byte used when there is no best-fit mapping. */
     unsigned char bestfit_replacement_byte;
+
+    // Request Line parsing options.
+
+    /** Reaction to leading whitespace on the request line */
+    enum htp_unwanted_t requestline_leading_whitespace_unwanted;
+
 } htp_decoder_cfg_t;
 
 struct htp_cfg_t {

--- a/htp/htp_request_generic.c
+++ b/htp/htp_request_generic.c
@@ -251,6 +251,7 @@ htp_status_t htp_parse_request_line_generic_ex(htp_connp_t *connp, int nul_termi
     unsigned char *data = bstr_ptr(tx->request_line);
     size_t len = bstr_len(tx->request_line);
     size_t pos = 0;
+    size_t mstart = 0;
 
     if (nul_terminates) {
         // The line ends with the first NUL byte.
@@ -266,13 +267,20 @@ htp_status_t htp_parse_request_line_generic_ex(htp_connp_t *connp, int nul_termi
         pos = 0;
     }
 
+    // skip past leading whitespace. IIS allows this
+    while ((pos < len) && htp_is_space(data[pos])) pos++;
+    if (pos) {
+        htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Request line: leading whitespace");
+        mstart = pos;
+    }
+
     // The request method starts at the beginning of the
     // line and ends with the first whitespace character.
     while ((pos < len) && (!htp_is_space(data[pos]))) pos++;
 
     // No, we don't care if the method is empty.
 
-    tx->request_method = bstr_dup_mem(data, pos);
+    tx->request_method = bstr_dup_mem(data + mstart, pos - mstart);
     if (tx->request_method == NULL) return HTP_ERROR;
 
     #ifdef HTP_DEBUG

--- a/htp/htp_request_generic.c
+++ b/htp/htp_request_generic.c
@@ -272,6 +272,13 @@ htp_status_t htp_parse_request_line_generic_ex(htp_connp_t *connp, int nul_termi
     if (pos) {
         htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Request line: leading whitespace");
         mstart = pos;
+
+        if (connp->cfg->decoder_cfgs[HTP_DECODER_DEFAULTS].requestline_leading_whitespace_unwanted != HTP_UNWANTED_IGNORE) {
+            // reset mstart so that we copy the whitespace into the method
+            mstart = 0;
+            // set expected response code to this anomaly
+            tx->response_status_expected_number = connp->cfg->decoder_cfgs[HTP_DECODER_DEFAULTS].requestline_leading_whitespace_unwanted;
+        }
     }
 
     // The request method starts at the beginning of the

--- a/test/files/89-get-whitespace.t
+++ b/test/files/89-get-whitespace.t
@@ -1,0 +1,14 @@
+>>>
+ GET /?p=%20 HTTP/1.0
+User-Agent: Mozilla
+
+
+<<<
+HTTP/1.0 200 OK
+Date: Mon, 31 Aug 2009 20:25:50 GMT
+Server: Apache
+Connection: close
+Content-Type: text/html
+Content-Length: 12
+
+Hello World!

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1876,3 +1876,29 @@ TEST_F(ConnectionParsing, IncorrectHostAmbiguousWarning) {
    
     ASSERT_FALSE(tx->flags & HTP_HOST_AMBIGUOUS);
 }
+
+TEST_F(ConnectionParsing, GetWhitespace) {
+    int rc = test_run(home, "89-get-whitespace.t", cfg, &connp);
+    ASSERT_GE(rc, 0);
+
+    ASSERT_EQ(1, htp_list_size(connp->conn->transactions));
+
+    htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
+    ASSERT_TRUE(tx != NULL);
+
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "GET"));
+
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_uri, "/?p=%20"));
+
+    ASSERT_TRUE(tx->parsed_uri != NULL);
+
+    ASSERT_TRUE(tx->parsed_uri->query != NULL);
+
+    ASSERT_EQ(0, bstr_cmp_c(tx->parsed_uri->query, "p=%20"));
+
+    htp_param_t *p = htp_tx_req_get_param(tx, "p", 1);
+    ASSERT_TRUE(p != NULL);
+
+    ASSERT_EQ(0, bstr_cmp_c(p->value, " "));
+}
+

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1886,7 +1886,7 @@ TEST_F(ConnectionParsing, GetWhitespace) {
     htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
     ASSERT_TRUE(tx != NULL);
 
-    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "GET"));
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, " GET"));
 
     ASSERT_EQ(0, bstr_cmp_c(tx->request_uri, "/?p=%20"));
 


### PR DESCRIPTION
Fix handling of leading whitespace on the request line.
Also, make it a per-personality setting.

I wonder if adding the new option to htp_decoder_cfg_t breaks binary compatibility as that is in the htp_cfg_t as an array. Might need to add the option directly to the end of the htp_cfg_t in that case.

Comments are welcome.
