### PR TITLE
htp_connp_close: handle streams in error state

### DIFF
--- a/htp/htp_connection_parser.c
+++ b/htp/htp_connection_parser.c
@@ -49,8 +49,10 @@ void htp_connp_close(htp_connp_t *connp, const htp_time_t *timestamp) {
     htp_conn_close(connp->conn, timestamp);
 
     // Update internal flags
-    connp->in_status = HTP_STREAM_CLOSED;
-    connp->out_status = HTP_STREAM_CLOSED;
+    if (connp->in_status != HTP_STREAM_ERROR)
+        connp->in_status = HTP_STREAM_CLOSED;
+    if (connp->out_status != HTP_STREAM_ERROR)
+        connp->out_status = HTP_STREAM_CLOSED;
 
     // Call the parsers one last time, which will allow them
     // to process the events that depend on stream closure


### PR DESCRIPTION
A stream in the error state would not be handled correctly by
htp_connp_close. The error state would be overwritten to 'CLOSED'
and the final handling of the stream would follow.

This lead to a case where a null pointer dereference could happen.

If for whatever reason inflateInit2 failed, the stream would get
into an error state. By resetting the state, the parser would
later unconditionally invoke the decompressor. As it's setup
failed, this resulted in a null dereference.

This patch makes sure that htp_connp_close doesn't overwrite
the state. The functions called by htp_connp_close are able
to deal with an error state properly.
