### PR TITLE
Fixing warnings

### DIFF
--- a/htp/htp_transcoder.c
+++ b/htp/htp_transcoder.c
@@ -151,9 +151,9 @@ int htp_transcode_bstr(iconv_t cd, bstr *input, bstr **output) {
         return HTP_ERROR;
     }
 
-    unsigned const char *inbuf = bstr_ptr(input);
+    const char *inbuf = (const char *)bstr_ptr(input);
     size_t inleft = bstr_len(input);
-    unsigned char *outbuf = buf;
+    char *outbuf = (char *)buf;
     size_t outleft = buflen;
 
     int loop = 1;
@@ -174,7 +174,7 @@ int htp_transcode_bstr(iconv_t cd, bstr *input, bstr **output) {
                 // The output buffer is full
                 bstr_builder_append_mem(bb, buf, buflen - outleft);
 
-                outbuf = buf;
+                outbuf = (char *)buf;
                 outleft = buflen;
 
                 // Continue in the loop, as there's more work to do

--- a/htp/strlcat.c
+++ b/htp/strlcat.c
@@ -39,6 +39,7 @@ static char *rcsid = "$OpenBSD: strlcat.c,v 1.5 2001/01/13 16:17:24 millert Exp 
 
 #include <sys/types.h>
 #include <string.h>
+#include "htp_private.h"
 
 /*
  * Appends src to string dst of size siz (unlike strncat, siz is the
@@ -47,10 +48,7 @@ static char *rcsid = "$OpenBSD: strlcat.c,v 1.5 2001/01/13 16:17:24 millert Exp 
  * Returns strlen(initial dst) + strlen(src); if retval >= siz,
  * truncation occurred.
  */
-size_t strlcat(dst, src, siz)
-    char *dst;
-    const char *src;
-    size_t siz;
+size_t strlcat(char *dst, const char *src, size_t siz)
 {
     register char *d = dst;
     register const char *s = src;

--- a/htp/strlcpy.c
+++ b/htp/strlcpy.c
@@ -39,16 +39,14 @@ static char *rcsid = "$OpenBSD: strlcpy.c,v 1.4 1999/05/01 18:56:41 millert Exp 
 
 #include <sys/types.h>
 #include <string.h>
+#include "htp_private.h"
 
 /*
  * Copy src to string dst of size siz.  At most siz-1 characters
  * will be copied.  Always NUL terminates (unless siz == 0).
  * Returns strlen(src); if retval >= siz, truncation occurred.
  */
-size_t strlcpy(dst, src, siz)
-    char *dst;
-    const char *src;
-    size_t siz;
+size_t strlcpy(char *dst, const char *src, size_t siz)
 {
     register char *d = dst;
     register const char *s = src;


### PR DESCRIPTION
This fixes the following warnings:
strlcpy.c:49: warning: function declaration isn't a prototype
strlcat.c:51: warning: function declaration isn't a prototype
htp_transcoder.c:163: warning: dereferencing type-punned pointer will break strict-aliasing rules
