### PR TITLE
htp_private: include config.h header

### DIFF
--- a/htp/htp_private.h
+++ b/htp/htp_private.h
@@ -49,6 +49,10 @@ extern "C" {
 #define __STDC_FORMAT_MACROS
 #endif
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 #include <ctype.h>
 #include <errno.h>
 #include <iconv.h>


### PR DESCRIPTION
htp_private.h doesn't include "config.h",
but HAVE_STRLCAT and HAVE_STRLCPY are used.

This solves the following error on OS X 10.10:
In file included from htp_config.c:39:
./htp_private.h:237:8: error: expected parameter declarator
size_t strlcat(char *dst, const char *src, size_t size);
       ^
