### PR TITLE
Fix warning on OpenBSD

### DIFF
--- a/htp/strlcat.c
+++ b/htp/strlcat.c
@@ -27,6 +27,8 @@
 
 /* $Id: strlcatu.c,v 1.4 2003/10/20 15:03:27 chrisgreen Exp $ */
 
+#include "htp_private.h"
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -39,7 +41,6 @@ static char *rcsid = "$OpenBSD: strlcat.c,v 1.5 2001/01/13 16:17:24 millert Exp 
 
 #include <sys/types.h>
 #include <string.h>
-#include "htp_private.h"
 
 /*
  * Appends src to string dst of size siz (unlike strncat, siz is the

--- a/htp/strlcpy.c
+++ b/htp/strlcpy.c
@@ -27,6 +27,8 @@
 
 /* $Id: strlcpyu.c,v 1.4 2003/10/20 15:03:27 chrisgreen Exp $ */
 
+#include "htp_private.h"
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -39,7 +41,6 @@ static char *rcsid = "$OpenBSD: strlcpy.c,v 1.4 1999/05/01 18:56:41 millert Exp 
 
 #include <sys/types.h>
 #include <string.h>
-#include "htp_private.h"
 
 /*
  * Copy src to string dst of size siz.  At most siz-1 characters


### PR DESCRIPTION
strlcpy.c:73:0: error: ISO C forbids an empty translation unit [-Werror=pedantic]

strlcpy/strlcat functions are defined on OpenBSD, this means
the files are empty, and the warning appears.

This moves an include before of #ifndef
so the files are never empty
