### PR TITLE
[preview] Multi content encoding support v6

### DIFF
--- a/htp/htp_config.c
+++ b/htp/htp_config.c
@@ -156,8 +156,9 @@ htp_cfg_t *htp_config_create(void) {
     cfg->parse_request_cookies = 1;
     cfg->parse_request_auth = 1;
     cfg->extract_request_files = 0;
-    cfg->extract_request_files_limit = -1; // Use the parser default.   
-        
+    cfg->extract_request_files_limit = -1; // Use the parser default.
+    cfg->response_decompression_layer_limit = 2; // 2 layers seem fairly common
+
     // Default settings for URL-encoded data.
 
     htp_config_set_bestfit_map(cfg, HTP_DECODER_DEFAULTS, bestfit_1252);
@@ -895,4 +896,9 @@ void htp_config_set_requestline_leading_whitespace_unwanted(htp_cfg_t *cfg, enum
     if (ctx >= HTP_DECODER_CONTEXTS_MAX) return;
 
     cfg->requestline_leading_whitespace_unwanted = unwanted;
+}
+
+void htp_config_set_response_decompression_layer_limit(htp_cfg_t *cfg, int limit) {
+    if (cfg == NULL) return;
+    cfg->response_decompression_layer_limit = limit;
 }

--- a/htp/htp_config.h
+++ b/htp/htp_config.h
@@ -647,6 +647,14 @@ void htp_config_set_utf8_invalid_unwanted(htp_cfg_t *cfg, enum htp_decoder_ctx_t
  */
 void htp_config_set_requestline_leading_whitespace_unwanted(htp_cfg_t *cfg, enum htp_decoder_ctx_t ctx, enum htp_unwanted_t unwanted);
 
+/**
+ * Configures many layers of compression we try to decompress.
+ *
+ * @param[in] cfg
+ * @param[in] limit 0 disables limit
+ */
+void htp_config_set_response_decompression_layer_limit(htp_cfg_t *cfg, int limit);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/htp/htp_config_private.h
+++ b/htp/htp_config_private.h
@@ -339,6 +339,9 @@ struct htp_cfg_t {
 
     /** Reaction to leading whitespace on the request line */
     enum htp_unwanted_t requestline_leading_whitespace_unwanted;
+
+    /** How many layers of compression we will decompress (0 => no limit). */
+    int response_decompression_layer_limit;
 };
 
 #ifdef	__cplusplus

--- a/htp/htp_decompressors.c
+++ b/htp/htp_decompressors.c
@@ -42,6 +42,7 @@
 
 /**
  * Decompress a chunk of gzip-compressed data.
+ * If we have more than one decompressor, call this function recursively.
  *
  * @param[in] drec
  * @param[in] d
@@ -59,13 +60,17 @@ static htp_status_t htp_gzip_decompressor_decompress(htp_decompressor_gzip_t *dr
         dout.data = NULL;
         dout.len = 0;
 
-        // Send decompressed data to the callback.
-        htp_status_t callback_rc = drec->super.callback(&dout);
-        if (callback_rc != HTP_OK) {
-            inflateEnd(&drec->stream);
-            drec->zlib_initialized = 0;
+        if (drec->super.next != NULL) {
+            return htp_gzip_decompressor_decompress((htp_decompressor_gzip_t *)drec->super.next, &dout);
+        } else {
+            // Send decompressed data to the callback.
+            htp_status_t callback_rc = drec->super.callback(&dout);
+            if (callback_rc != HTP_OK) {
+                inflateEnd(&drec->stream);
+                drec->zlib_initialized = 0;
 
-            return callback_rc;
+                return callback_rc;
+            }
         }
 
         return HTP_OK;
@@ -88,13 +93,21 @@ static htp_status_t htp_gzip_decompressor_decompress(htp_decompressor_gzip_t *dr
             d2.data = drec->buffer;
             d2.len = GZIP_BUF_SIZE;
 
-            // Send decompressed data to callback.
-            htp_status_t callback_rc = drec->super.callback(&d2);
-            if (callback_rc != HTP_OK) {
-                inflateEnd(&drec->stream);
-                drec->zlib_initialized = 0;
-                
-                return callback_rc;
+            if (drec->super.next != NULL) {
+                htp_tx_data_t d3;
+                d3.tx = d->tx;
+                d3.data = drec->buffer;
+                d3.len = GZIP_BUF_SIZE;
+                return htp_gzip_decompressor_decompress((htp_decompressor_gzip_t *)drec->super.next, &d3);
+            } else {
+                // Send decompressed data to callback.
+                htp_status_t callback_rc = drec->super.callback(&d2);
+                if (callback_rc != HTP_OK) {
+                    inflateEnd(&drec->stream);
+                    drec->zlib_initialized = 0;
+
+                    return callback_rc;
+                }
             }
 
             drec->stream.next_out = drec->buffer;
@@ -116,15 +129,23 @@ static htp_status_t htp_gzip_decompressor_decompress(htp_decompressor_gzip_t *dr
             d2.data = drec->buffer;
             d2.len = len;
 
-            // Send decompressed data to the callback.
-            htp_status_t callback_rc = drec->super.callback(&d2);
-            if (callback_rc != HTP_OK) {
-                inflateEnd(&drec->stream);
-                drec->zlib_initialized = 0;
-                
-                return callback_rc;
-            }
+            if (drec->super.next != NULL) {
+                htp_tx_data_t d3;
+                d3.tx = d->tx;
+                d3.data = drec->buffer;
+                d3.len = len;
+                return htp_gzip_decompressor_decompress((htp_decompressor_gzip_t *)drec->super.next, &d3);
 
+            } else {
+                // Send decompressed data to the callback.
+                htp_status_t callback_rc = drec->super.callback(&d2);
+                if (callback_rc != HTP_OK) {
+                    inflateEnd(&drec->stream);
+                    drec->zlib_initialized = 0;
+
+                    return callback_rc;
+                }
+            }
             // TODO Handle trailer.
 
             return HTP_OK;
@@ -173,6 +194,7 @@ htp_decompressor_t *htp_gzip_decompressor_create(htp_connp_t *connp, enum htp_co
 
     drec->super.decompress = (int (*)(htp_decompressor_t *, htp_tx_data_t *))htp_gzip_decompressor_decompress;
     drec->super.destroy = (void (*)(htp_decompressor_t *))htp_gzip_decompressor_destroy;
+    drec->super.next = NULL;
 
     drec->buffer = malloc(GZIP_BUF_SIZE);
     if (drec->buffer == NULL) {

--- a/htp/htp_decompressors.h
+++ b/htp/htp_decompressors.h
@@ -57,6 +57,7 @@ struct htp_decompressor_t {
     htp_status_t (*decompress)(htp_decompressor_t *, htp_tx_data_t *);
     htp_status_t (*callback)(htp_tx_data_t *);
     void (*destroy)(htp_decompressor_t *);
+    struct htp_decompressor_t *next;
 };
 
 struct htp_decompressor_gzip_t {


### PR DESCRIPTION
Support multiple layers of compression in response bodies. 2 layers seem
quite common in some proxy environments.

To do so, make htp_tx_t::htp_decompressor_t a list instead of a single
instance. This allows for stacked encoding.

Setting up of multiple content encoding is a slow path.

Add a limit to how many layers of compressed data will be uncompressed.
Defaults to 2, but is configurable. Setting it to 0 disables the limit.

If the limit is reached, a warning will be recorded.
