### PR TITLE
fix pkgconfig include dir

### DIFF
--- a/htp.pc.in
+++ b/htp.pc.in
@@ -7,5 +7,5 @@ Name: @PACKAGE_NAME@
 Description: A security-aware HTTP parser, designed for use in IDS/IPS and WAF products.
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lhtp
-Cflags: -I${includedir}/htp -I${libdir}/htp/include
+Cflags: -I${includedir} -I${libdir}/htp/include
 


### PR DESCRIPTION
Software using libhtp are including 'htp/htp.h' so the path must
simply be ${includedir} and not ${includedir}/htp.
