### PR TITLE
htp/htp_util.c: Do not invoke callbacks in htp_req_run_hook_body_data() when there is no tx running.

### DIFF
--- a/htp/htp_util.c
+++ b/htp/htp_util.c
@@ -2358,6 +2358,9 @@ htp_status_t htp_req_run_hook_body_data(htp_connp_t *connp, htp_tx_data_t *d) {
     // Do not invoke callbacks with an empty data chunk
     if ((d->data != NULL) && (d->len == 0)) return HTP_OK;
 
+    // Do not invoke callbacks without a transaction.
+    if (connp->in_tx == NULL) return HTP_OK;
+
     // Run transaction hooks first
     htp_status_t rc = htp_hook_run_all(connp->in_tx->hook_request_body_data, d);
     if (rc != HTP_OK) return rc;


### PR DESCRIPTION
I accidentally merged two other pull requests with this one. This comment is an artifact of that mistake and I don't seem to be able to remove it.
