### PR TITLE
    test/test.c: Coverity-identified missing break in switch.

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -242,6 +242,7 @@ static int parse_filename(const char *filename, char **remote_addr, int *remote_
                 break;
             case 4:
                 *local_addr = strdup(p);
+                break;
             case 5:
                 *local_port = atoi(p);
                 break;


### PR DESCRIPTION
test/test.c: Coverity-identified missing break in switch.
