### PR TITLE
Fix uninitialized htp_tx_t::is_last value in htp_tx_res_process_body_…

### DIFF
--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -787,6 +787,7 @@ htp_status_t htp_tx_res_process_body_data_ex(htp_tx_t *tx, const void *data, siz
     d.tx = tx;
     d.data = (unsigned char *) data;
     d.len = len;
+    d.is_last = 0;
 
     // Keep track of body size before decompression.
     tx->response_message_len += d.len;


### PR DESCRIPTION
…data_ex()

This value should obviously be initialized otherwise this leads to first TX data chunk captured being is_last since the value of d allocated on stack is uninitialized and != 0.
