### PR TITLE
Trigger request line parsing on incomplete request

### DIFF
--- a/htp/htp_private.h
+++ b/htp/htp_private.h
@@ -87,6 +87,7 @@ extern "C" {
 
 htp_status_t htp_connp_REQ_IDLE(htp_connp_t *connp);
 htp_status_t htp_connp_REQ_LINE(htp_connp_t *connp);
+htp_status_t htp_connp_REQ_LINE_complete(htp_connp_t *connp);
 htp_status_t htp_connp_REQ_PROTOCOL(htp_connp_t *connp);
 htp_status_t htp_connp_REQ_HEADERS(htp_connp_t *connp);
 htp_status_t htp_connp_REQ_CONNECT_CHECK(htp_connp_t *connp);

--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -194,6 +194,9 @@ static htp_status_t htp_connp_req_buffer(htp_connp_t *connp) {
     unsigned char *data = connp->in_current_data + connp->in_current_consume_offset;
     size_t len = connp->in_current_read_offset - connp->in_current_consume_offset;
 
+    if (len == 0)
+        return HTP_OK;
+
     // Check the hard (buffering) limit.
    
     size_t newlen = connp->in_buf_size + len;

--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -1155,6 +1155,17 @@ htp_status_t htp_tx_state_response_start(htp_tx_t *tx) {
         tx->response_progress = HTP_RESPONSE_LINE;
     }
 
+    /* If at this point we have no method and no uri and our status
+     * is still htp_connp_REQ_LINE, we likely have timed out request
+     * or a overly long request */
+    if (tx->request_method == HTP_M_UNKNOWN && tx->request_uri == NULL && tx->connp->in_state == htp_connp_REQ_LINE) {
+        htp_log(tx->connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Request line incomplete");
+
+        if (htp_connp_REQ_LINE_complete(tx->connp) != HTP_OK) {
+            return HTP_ERROR;
+        }
+    }
+
     return HTP_OK;
 }
 

--- a/test/files/90-request-uri-too-large.t
+++ b/test/files/90-request-uri-too-large.t
@@ -1,0 +1,17 @@
+>>>
+GET /blaaaaaaaaaaaaaaaaaaaaaaaaa
+<<<
+HTTP/1.0 414 Request-URI Too Large
+Server: MyBigFatServer
+Mime-Version: 1.0
+Date: Fri, 27 Sep 2013 16:37:37 GMT
+Content-Type: text/html
+Content-Length: 139
+Expires: Fri, 27 Sep 2013 16:37:37 GMT
+
+<HTML><HEAD>
+<TITLE>Request-URI Too Large</TITLE>
+</HEAD><BODY>
+<H1>Request-URI Too Large</H1>
+The Request-URI is Too Large
+</BODY></HTML>

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1848,7 +1848,7 @@ TEST_F(ConnectionParsing, PartialRequestTimeout) {
     htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
     ASSERT_TRUE(tx != NULL);
 
-    ASSERT_EQ(HTP_REQUEST_LINE, tx->request_progress);
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
     ASSERT_EQ(HTP_RESPONSE_COMPLETE, tx->response_progress);
 }
 
@@ -1902,3 +1902,15 @@ TEST_F(ConnectionParsing, GetWhitespace) {
     ASSERT_EQ(0, bstr_cmp_c(p->value, " "));
 }
 
+TEST_F(ConnectionParsing, RequestUriTooLarge) {
+    int rc = test_run(home, "90-request-uri-too-large.t", cfg, &connp);
+    ASSERT_GE(rc, 0);
+
+    ASSERT_EQ(1, htp_list_size(connp->conn->transactions));
+
+    htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
+    ASSERT_TRUE(tx != NULL);
+
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+    ASSERT_EQ(HTP_RESPONSE_COMPLETE, tx->response_progress);
+}


### PR DESCRIPTION
When a response is received before the full request is received, we
are handling either with timeout case (where the server no longer
waits for the rest of the request) or a request too big case.

In such cases the request line would not be parsed if the state for
the request was still 'request line'.

This patch forces request line parsing in such cases.
