### PR TITLE
connect: handle response headers with 200 response

### DIFF
--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -479,7 +479,10 @@ htp_status_t htp_connp_RES_BODY_DETERMINE(htp_connp_t *connp) {
             // if we need to parse or ignore it. So on the response
             // side we wrap up the tx and wait.
             connp->out_state = htp_connp_RES_FINALIZE;
-            return HTP_OK;
+
+            // we may have response headers
+            htp_status_t rc = htp_tx_state_response_headers(connp->out_tx);
+            return rc;
         } else {
             // This is a failed CONNECT stream, which means that
             // we can unblock request parsing


### PR DESCRIPTION
Lots of CONNECT requests are answered by:
    HTTP/1.0 200 Connection Established\r\n\r\n

The 2nd set of \r\n is considered to be part of the header. Due to some
missing header handling, in the CONNECT case this would be handled after
the tx was cleaned up. This would lead to the invocation of the
response header callback with a NULL tx.
