### PR TITLE
Fix warning on OS X.

### DIFF
--- a/htp/htp_util.c
+++ b/htp/htp_util.c
@@ -2085,7 +2085,7 @@ void fprint_raw_data_ex(FILE *stream, const char *name, const void *_data, size_
     char buf[160];
     size_t len = offset + printlen;
 
-    fprintf(stream, "\n%s: ptr %p offset %" PRIu64 " len %" PRIu64"\n", name, data, (uint64_t) offset, (uint64_t) len);
+    fprintf(stream, "\n%s: ptr %p offset %" PRIu64 " len %" PRIu64"\n", name, (void*) data, (uint64_t) offset, (uint64_t) len);
 
     while (offset < len) {
         size_t i;


### PR DESCRIPTION
When building on OS X (haven't tried others) there is a warning when building htp_util.c.

```
htp_util.c:2088:79: warning: format specifies type 'void *' but the argument has type 'const unsigned char *' [-Wformat-pedantic]
    fprintf(stream, "\n%s: ptr %p offset %" PRIu64 " len %" PRIu64"\n", name, data, (uint64_t) offset, (uint64_t) len);
                               ~~                                             ^~~~
                               %s
1 warning generated.
```

This commit fixes it by casting to a void pointer.
