### PR TITLE
Buildsys v3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -114,14 +114,12 @@ case "$OS" in
         FreeBSD*)
                 AC_MSG_RESULT(FreeBSD)
                 OS_FREEBSD="true"
-                NO_STACK_PROTECTOR="true"
                 CPPFLAGS="${CPPFLAGS} -I/usr/local/include"
                 LDFLAGS="${LDFLAGS} -L/usr/local/lib"
         ;;
         OpenBSD*)
                 AC_MSG_RESULT(OpenBSD)
                 OS_OPENBSD="true"
-                NO_STACK_PROTECTOR="true"
                 CPPFLAGS="${CPPFLAGS} -I/usr/local/include"
                 LDFLAGS="${LDFLAGS} -L/usr/local/lib"
         ;;

--- a/configure.ac
+++ b/configure.ac
@@ -195,6 +195,15 @@ if test "$gcc_have_format_security" != "yes"; then
     CFLAGS="${TMPCFLAGS}"
 fi
 
+AC_MSG_CHECKING(for gcc support of -fPIC)
+TMPCFLAGS="${CFLAGS}"
+CFLAGS="${CFLAGS} -fPIC"
+AC_TRY_COMPILE(,,[gcc_have_fpic=yes],[gcc_have_fpic=no])
+AC_MSG_RESULT($gcc_have_fpic)
+if test "$gcc_have_fpic" != "yes"; then
+    CFLAGS="${TMPCFLAGS}"
+fi
+
 dnl -----------------------------------------------
 dnl Check for doxygen
 dnl -----------------------------------------------


### PR DESCRIPTION
- Enable  stack protection on FreeBSD and OpenBSD.
- Enable -fPIC if available.

Tested on OpenBSD 5.4, 6.0, HardenedBSD 11, FreeBSD 10.3 (and more generally against the full Suricata QA).
