### PR TITLE
Fix for impossible-to-disable configure flags

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -51,7 +51,7 @@ dnl --------------------------------
 dnl Options
 dnl --------------------------------
 
-AC_ARG_ENABLE(debug, [  --enable-debug  Enable debug mode], [ enable_debug=yes ])
+AC_ARG_ENABLE(debug, [  --enable-debug  Enable debug mode],, [ enable_debug=yes ])
 if test "$enable_debug" = "yes"; then
     CFLAGS="${CFLAGS} -DHTP_DEBUG"
     echo "Debug mode enabled"
@@ -59,7 +59,7 @@ fi
 
 OLEVEL=2
 
-AC_ARG_ENABLE(devmode, [  --enable-devmode  Enable development mode], [ enable_devmode=yes ])
+AC_ARG_ENABLE(devmode, [  --enable-devmode  Enable development mode],, [ enable_devmode=yes ])
 if test "$enable_devmode" = "yes"; then
     OLEVEL=0
     CFLAGS="${CFLAGS} -Werror -Wfatal-errors"
@@ -67,7 +67,7 @@ if test "$enable_devmode" = "yes"; then
     echo "Development mode enabled"
 fi
 
-AC_ARG_ENABLE(gcov, [  --enable-gcov  Enable gcov support], [ enable_gcov=yes ])
+AC_ARG_ENABLE(gcov, [  --enable-gcov  Enable gcov support],, [ enable_gcov=yes ])
 if test "$enable_gcov" = "yes"; then
     OLEVEL=0
     CFLAGS="${CFLAGS} --coverage -fprofile-arcs -ftest-coverage"


### PR DESCRIPTION
The --enable-debug, --enable-devmode, and --enable-gcov flags were all
set to force the value of "yes" when the flag was set, _not_ when not
set, due to a missing AC_ARG_ENABLE comma.