### PR TITLE
Integration with oss-fuzz

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -9,11 +9,14 @@ AM_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir)/htp -Wno-write-strings -DGTEST_U
 
 AUTOMAKE_OPTIONS = subdir-objects
 EXTRA_DIST = files
-check_PROGRAMS = test_all
+check_PROGRAMS = test_all test_fuzz
 check_LIBRARIES = libgtest.a
 
 test_all_SOURCES = test_bstr.cpp test_gunzip.cpp test_hybrid.cpp test_main.cpp test_multipart.cpp test.c test.h test_utils.cpp test_bench.cpp
 test_all_LDADD = libgtest.a -lpthread $(LDADD)
+
+test_fuzz_SOURCES = fuzz/onefile.c fuzz/fuzz_htp.c
+test_fuzz_LDADD = $(LDADD)
 
 libgtest_a_SOURCES = gtest/gtest-all.cc gtest/gtest_main.cc gtest/gtest.h
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -15,7 +15,7 @@ check_LIBRARIES = libgtest.a
 test_all_SOURCES = test_bstr.cpp test_gunzip.cpp test_hybrid.cpp test_main.cpp test_multipart.cpp test.c test.h test_utils.cpp test_bench.cpp
 test_all_LDADD = libgtest.a -lpthread $(LDADD)
 
-test_fuzz_SOURCES = fuzz/onefile.c fuzz/fuzz_htp.c
+test_fuzz_SOURCES = fuzz/onefile.c fuzz/fuzz_htp.c test.c
 test_fuzz_LDADD = $(LDADD)
 
 libgtest_a_SOURCES = gtest/gtest-all.cc gtest/gtest_main.cc gtest/gtest.h

--- a/test/fuzz/fuzz_htp.c
+++ b/test/fuzz/fuzz_htp.c
@@ -1,0 +1,95 @@
+/**
+ * @file
+ * @author Philippe Antoine <contact@catenacyber.fr>
+ * fuzz harness for libhtp
+ */
+
+
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include <htp/htp.h>
+
+
+FILE * logfile = NULL;
+
+
+/**
+ * Invoked at the end of every transaction. 
+ *
+ * @param[in] connp
+ */
+static int callback_response(htp_tx_t *out_tx) {
+    if (out_tx != NULL) {
+        char *x = bstr_util_strdup_to_c(out_tx->request_line);
+        fprintf(logfile, "%s\n", x);
+        free(x);
+    }
+    return 0;
+}
+
+/**
+ * Invoked every time LibHTP wants to log. 
+ *
+ * @param[in] log
+ */
+static int callback_log(htp_log_t *log) {
+    fprintf(logfile, "[%d][code %d][file %s][line %d] %s\n",
+        log->level, log->code, log->file, log->line, log->msg);
+    return 0;
+}
+
+void fuzz_openFile(const char * name) {
+    if (logfile != NULL) {
+        fclose(logfile);
+    }
+    logfile = fopen(name, "w");
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+    htp_cfg_t *cfg;
+    size_t SizeReq;
+    htp_connp_t * connp;
+
+    //initialize output file
+    if (logfile == NULL) {
+        logfile = fopen("/dev/null", "w");
+        if (logfile == NULL) {
+            return 0;
+        }
+    }
+
+    if (Size < 3) {
+        return 0;
+    }
+    SizeReq = (Data[1] << 8) | Data[2];
+    if (Size < 3 + SizeReq) {
+        return 0;
+    }
+
+    // Create LibHTP configuration
+    cfg = htp_config_create();
+    if (htp_config_set_server_personality(cfg, Data[0]) != HTP_OK) {
+        htp_config_destroy(cfg);
+        return 0;
+    }
+    htp_config_register_response_complete(cfg, callback_response);
+    htp_config_register_log(cfg, callback_log);
+
+    connp = htp_connp_create(cfg);
+    htp_connp_req_data(connp, 0, Data+3, SizeReq);
+    htp_connp_res_data(connp, 0, Data+3+SizeReq, Size - (3+SizeReq) );
+    htp_connp_destroy_all(connp);
+
+    // Destroy LibHTP configuration    
+    htp_config_destroy(cfg);
+
+    return 0;
+}
+

--- a/test/fuzz/onefile.c
+++ b/test/fuzz/onefile.c
@@ -1,0 +1,54 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size);
+void fuzz_openFile(const char * name);
+
+int main(int argc, char** argv)
+{
+    FILE * fp;
+    uint8_t *Data;
+    size_t Size;
+
+    if (argc == 3) {
+        fuzz_openFile(argv[2]);
+    } else if (argc != 2) {
+        return 1;
+    }
+    //opens the file, get its size, and reads it into a buffer
+    fp = fopen(argv[1], "rb");
+    if (fp == NULL) {
+        return 2;
+    }
+    if (fseek(fp, 0L, SEEK_END) != 0) {
+        fclose(fp);
+        return 2;
+    }
+    Size = ftell(fp);
+    if (Size == (size_t) -1) {
+        fclose(fp);
+        return 2;
+    }
+    if (fseek(fp, 0L, SEEK_SET) != 0) {
+        fclose(fp);
+        return 2;
+    }
+    Data = malloc(Size);
+    if (Data == NULL) {
+        fclose(fp);
+        return 2;
+    }
+    if (fread(Data, Size, 1, fp) != 1) {
+        fclose(fp);
+        free(Data);
+        return 2;
+    }
+
+    //lauch fuzzer
+    LLVMFuzzerTestOneInput(Data, Size);
+    free(Data);
+    fclose(fp);
+    return 0;
+}
+

--- a/test/test.c
+++ b/test/test.c
@@ -164,7 +164,7 @@ static void test_start(test_t *test) {
  *         success, test->chunk will point to the beginning of the chunk, while
  *         test->chunk_len will contain its length.
  */
-static int test_next_chunk(test_t *test) {
+int test_next_chunk(test_t *test) {
     if (test->pos >= test->len) {
         return 0;
     }

--- a/test/test.c
+++ b/test/test.c
@@ -183,7 +183,13 @@ int test_next_chunk(test_t *test) {
 
             // Move over the boundary
             test->pos += 4;
+            if (test->pos >= test->len) {
+                return 0;
+            }
             if (test->buf[test->pos] == '\n') test->pos++;
+            if (test->pos >= test->len) {
+                return 0;
+            }
 
             // Start new chunk
             test->chunk = test->buf + test->pos;
@@ -205,6 +211,9 @@ int test_next_chunk(test_t *test) {
 
                 // Position at the next boundary line
                 test->pos++;
+                if (test->pos >= test->len) {
+                    return 0;
+                }
 
                 return 1;
             }

--- a/test/test.h
+++ b/test/test.h
@@ -73,6 +73,8 @@ struct test_t {
 int test_run(const char *testsdir, const char *testname, htp_cfg_t *cfg, htp_connp_t **connp);
 int test_run_ex(const char *testsdir, const char *testname, htp_cfg_t *cfg, htp_connp_t **connp, int clone_count);
 
+int test_next_chunk(test_t *test);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This fuzz harness reuses code from test.c (for the input format)
There are some fixes to it to avoid overflows with some invalid inputs

I used `htp_config_set_server_personality(cfg, HTP_SERVER_IDS)` to maximize coverage.

I think that the build system for this can be improved (there is a specific target test_fuzz to build a standalone tool, which is not included during the main build)