### PR TITLE
Fuzz harness : aborts if /dev/null cant be opened

### DIFF
--- a/test/fuzz/fuzz_htp.c
+++ b/test/fuzz/fuzz_htp.c
@@ -63,7 +63,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     if (logfile == NULL) {
         logfile = fopen("/dev/null", "w");
         if (logfile == NULL) {
-            return 0;
+            abort();
         }
     }
 


### PR DESCRIPTION
As recommended in https://github.com/google/oss-fuzz/pull/1949#discussion_r241523058
