### PR TITLE
Optimizes htp_list_array_replace avoiding useless loop

### DIFF
--- a/htp/htp_list.c
+++ b/htp/htp_list.c
@@ -172,18 +172,7 @@ htp_status_t htp_list_array_replace(htp_list_array_t *l, size_t idx, void *e) {
 
     if (idx + 1 > l->current_size) return HTP_DECLINED;
 
-    size_t i;
-    // Do we need to check for this integer overflow ?
-    if (l->first > SIZE_MAX - idx) {
-        // l->first + idx > SIZE_MAX =>
-        // l->first + idx > l->max_size =>
-        // idx > l->max_size - l->first
-        i = idx - (l->max_size - l->first);
-    } else {
-        i = (l->first + idx) % l->max_size;
-    }
-
-    l->elements[i] = e;
+    l->elements[(l->first + idx) % l->max_size] = e;
 
     return HTP_OK;
 }

--- a/htp/htp_list.c
+++ b/htp/htp_list.c
@@ -172,12 +172,15 @@ htp_status_t htp_list_array_replace(htp_list_array_t *l, size_t idx, void *e) {
 
     if (idx + 1 > l->current_size) return HTP_DECLINED;
 
-    size_t i = l->first;
-
-    while (idx--) {
-        if (++i == l->max_size) {
-            i = 0;
-        }
+    size_t i;
+    // Do we need to check for this integer overflow ?
+    if (l->first > SIZE_MAX - idx) {
+        // l->first + idx > SIZE_MAX =>
+        // l->first + idx > l->max_size =>
+        // idx > l->max_size - l->first
+        i = idx - (l->max_size - l->first);
+    } else {
+        i = (l->first + idx) % l->max_size;
     }
 
     l->elements[i] = e;


### PR DESCRIPTION
Going from 7 to 6 seconds on fuzzing corpus

I am not sure that we need to check for the integer overflow...