### PR TITLE
Optimizes htp_list_array_replace avoiding useless loop

### DIFF
--- a/htp/htp_list.c
+++ b/htp/htp_list.c
@@ -172,15 +172,7 @@ htp_status_t htp_list_array_replace(htp_list_array_t *l, size_t idx, void *e) {
 
     if (idx + 1 > l->current_size) return HTP_DECLINED;
 
-    size_t i = l->first;
-
-    while (idx--) {
-        if (++i == l->max_size) {
-            i = 0;
-        }
-    }
-
-    l->elements[i] = e;
+    l->elements[(l->first + idx) % l->max_size] = e;
 
     return HTP_OK;
 }


### PR DESCRIPTION
Going from 7 to 6 seconds on fuzzing corpus

Following #177 in one single squashed commit