### PR TITLE
htp.pc.in: add @LIBICONV@ to LIBS

### DIFF
--- a/htp.pc.in
+++ b/htp.pc.in
@@ -6,6 +6,6 @@ includedir=@includedir@
 Name: @PACKAGE_NAME@
 Description: A security-aware HTTP parser, designed for use in IDS/IPS and WAF products.
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lhtp
+Libs: -L${libdir} -lhtp @LIBICONV@
 Cflags: -I${includedir} -I${libdir}/htp/include
 


### PR DESCRIPTION
Update htp.pc.in to add the optional dependency libiconv (@LIBICONV@) to
Libs

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>