### PR TITLE
htp.pc.in: move libiconv in Libs.private

### DIFF
--- a/htp.pc.in
+++ b/htp.pc.in
@@ -6,6 +6,7 @@ includedir=@includedir@
 Name: @PACKAGE_NAME@
 Description: A security-aware HTTP parser, designed for use in IDS/IPS and WAF products.
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} -lhtp @LIBICONV@
+Libs: -L${libdir} -lhtp
+Libs.private: @LIBICONV@
 Cflags: -I${includedir} -I${libdir}/htp/include
 


### PR DESCRIPTION
GNU libiconv is a private library so move it from Libs to Libs.private
in htp.pc.in

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>