### PR TITLE
headers: limits to two the number of duplicate headers

### DIFF
--- a/htp/htp_request_generic.c
+++ b/htp/htp_request_generic.c
@@ -70,6 +70,17 @@ htp_status_t htp_process_request_header_generic(htp_connp_t *connp, unsigned cha
     if (h_existing != NULL) {
         // TODO Do we want to have a list of the headers that are
         //      allowed to be combined in this way?
+        if (h_existing->flags & HTP_FIELD_REPEATED == 0) {
+            // This is the second occurence for this header.
+            htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Repetition for header");
+        } else {
+            bstr_free(h->name);
+            bstr_free(h->value);
+            free(h);
+            return HTP_OK;
+        }
+        // Keep track of repeated same-name headers.
+        h_existing->flags |= HTP_FIELD_REPEATED;
 
         // Add to the existing header.
         bstr *new_value = bstr_expand(h_existing->value, bstr_len(h_existing->value) + 2 + bstr_len(h->value));
@@ -88,9 +99,6 @@ htp_status_t htp_process_request_header_generic(htp_connp_t *connp, unsigned cha
         bstr_free(h->name);
         bstr_free(h->value);
         free(h);
-
-        // Keep track of repeated same-name headers.
-        h_existing->flags |= HTP_FIELD_REPEATED;
     } else {
         // Add as a new header.
         if (htp_table_add(connp->in_tx->request_headers, h->name, h) != HTP_OK) {

--- a/htp/htp_response_generic.c
+++ b/htp/htp_response_generic.c
@@ -256,16 +256,17 @@ htp_status_t htp_process_response_header_generic(htp_connp_t *connp, unsigned ch
     htp_header_t *h_existing = htp_table_get(connp->out_tx->response_headers, h->name);
     if (h_existing != NULL) {
         // Keep track of repeated same-name headers.
-        if (h_existing->flags & HTP_FIELD_REPEATED) {
-            // This is at least the third occurence for this header.
+        if (h_existing->flags & HTP_FIELD_REPEATED == 0) {
+            // This is the second occurence for this header.
             htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Repetition for header");
+        } else {
             bstr_free(h->name);
             bstr_free(h->value);
             free(h);
             return HTP_OK;
         }
         h_existing->flags |= HTP_FIELD_REPEATED;
-                
+
         // Having multiple C-L headers is against the RFC but many
         // browsers ignore the subsequent headers if the values are the same.
         if (bstr_cmp_c_nocase(h->name, "Content-Length") == 0) {

--- a/htp/htp_response_generic.c
+++ b/htp/htp_response_generic.c
@@ -257,15 +257,12 @@ htp_status_t htp_process_response_header_generic(htp_connp_t *connp, unsigned ch
     if (h_existing != NULL) {
         // Keep track of repeated same-name headers.
         if (h_existing->flags & HTP_FIELD_REPEATED) {
-            // This is the third occurence for this header.
-            if (!(h_existing->flags & HTP_FIELD_FOLDED)) {
-                htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0, "Third repetition for header");
-                h_existing->flags |= HTP_FIELD_FOLDED;
-            }
+            // This is at least the third occurence for this header.
+            htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Repetition for header");
             bstr_free(h->name);
             bstr_free(h->value);
             free(h);
-            return HTP_ERROR;
+            return HTP_OK;
         }
         h_existing->flags |= HTP_FIELD_REPEATED;
                 


### PR DESCRIPTION
This comes from a timeout generated by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=13255

We can abuse libhtp to do lots of `realloc` with headers such as :
```
a:1
a:2
a:3
a:1
```
that get transformed into `a:"1, 2, 3, 1"`

See discussion here : https://github.com/google/oss-fuzz/issues/2180

I have two points for which I would like an opinion :

@victorjulien when you said 
> raise the event
do you mean a call to `htp_log` or some other mechanism ?

Is setting the `HTP_FIELD_FOLDED` flag for the header the right way to limit the number of raised events ?