### PR TITLE
http: handles multiple content-length headers

### DIFF
--- a/htp/htp_response_generic.c
+++ b/htp/htp_response_generic.c
@@ -268,19 +268,18 @@ htp_status_t htp_process_response_header_generic(htp_connp_t *connp, unsigned ch
 
             existing_cl = htp_parse_content_length(h_existing->value);
             new_cl = htp_parse_content_length(h->value);
-            if ((existing_cl == -1) || (new_cl == -1) || (existing_cl != new_cl)) {
-                // Ambiguous response C-L value.
-                htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0, "Ambiguous response C-L value");
-
-                bstr_free(h->name);
-                bstr_free(h->value);
-                free(h);
-                
-                return HTP_ERROR;
+            // Ambiguous response C-L value.
+            if (existing_cl == -1 || (existing_cl != new_cl)) {
+                // Pick the new value
+                bstr *tmp = h_existing->value;
+                h_existing->value = h->value;
+                h->value = tmp;
+                htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Ambiguous response C-L value");
+            } else if (new_cl == -1) {
+                htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Ambiguous response C-L value");
             }
-
             // Ignoring the new C-L header that has the same value as the previous ones.
-        } else {            
+        } else {
             // Add to the existing header.
 
             bstr *new_value = bstr_expand(h_existing->value, bstr_len(h_existing->value) + 2 + bstr_len(h->value));

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1668,7 +1668,7 @@ TEST_F(ConnectionParsing, ResponseMultipleCl) {
 
 TEST_F(ConnectionParsing, ResponseMultipleClMismatch) {
     int rc = test_run(home, "88-response-multiple-cl-mismatch.t", cfg, &connp);
-    ASSERT_LT(rc, 0); // Expect error
+    ASSERT_GE(rc, 0);
 
     ASSERT_EQ(1, htp_list_size(connp->conn->transactions));
 
@@ -1676,7 +1676,21 @@ TEST_F(ConnectionParsing, ResponseMultipleClMismatch) {
     ASSERT_TRUE(tx != NULL);
 
     ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
-    ASSERT_EQ(HTP_RESPONSE_HEADERS, tx->response_progress);
+    ASSERT_EQ(HTP_RESPONSE_COMPLETE, tx->response_progress);
+
+    ASSERT_TRUE(tx->flags & HTP_REQUEST_SMUGGLING);
+
+    htp_header_t *h = (htp_header_t *)htp_table_get_c(tx->response_headers, "Content-Length");
+    ASSERT_TRUE(h != NULL);
+    ASSERT_TRUE(h->value != NULL);
+    ASSERT_TRUE(h->flags & HTP_FIELD_REPEATED);
+
+    ASSERT_EQ(0, bstr_cmp_c(h->value, "12"));
+
+    ASSERT_EQ(1, htp_list_size(tx->conn->messages));
+    htp_log_t *log = (htp_log_t *) htp_list_get(tx->conn->messages, 0);
+    ASSERT_TRUE(log != NULL);
+    ASSERT_EQ(HTP_LOG_WARNING, log->level);
 }
 
 TEST_F(ConnectionParsing, ResponseInvalidCl) {


### PR DESCRIPTION
Logs only as warning
Takes the latest value as the valid one
Same goes for requests and responses

Fixes #1776
Follows #187