### PR TITLE
fix build without GNU libiconv

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -155,6 +155,24 @@ sinclude(m4/lib-link.m4)
 sinclude(m4/lib-prefix.m4)
 AM_ICONV
 
+# iconvctl is not standard, it is defined only in GNU libiconv
+AC_MSG_CHECKING(for iconvctl)
+TMPLIBS="${LIBS}"
+LIBS="${LIBS} ${LIBICONV}"
+
+AC_TRY_LINK([#include <stdlib.h>
+             #include <iconv.h>],
+            [int iconv_param = 0;
+             iconv_t cd = iconv_open("","");
+             iconvctl(cd, ICONV_SET_DISCARD_ILSEQ, &iconv_param);
+             iconv_close(cd);],
+            [ac_cv_func_iconvctl=yes])
+AC_MSG_RESULT($ac_cv_func_iconvctl)
+if test "$ac_cv_func_iconvctl" == yes; then
+    AC_DEFINE(HAVE_ICONVCTL,1,"Define to 1 if you have the `iconvctl' function.")
+fi
+LIBS="${TMPLIBS}"
+
 dnl -----------------------------------------------
 dnl Check and enable the GCC opts we want to use.
 dnl We may need to add more checks

--- a/htp/htp_transcoder.c
+++ b/htp/htp_transcoder.c
@@ -64,7 +64,7 @@ int htp_transcode_params(htp_connp_t *connp, htp_table_t **params, int destroy_o
         return HTP_ERROR;
     }
 
-    #if (_LIBICONV_VERSION >= 0x0108)
+    #if (_LIBICONV_VERSION >= 0x0108 && HAVE_ICONVCTL)
     int iconv_param = 0;
     iconvctl(cd, ICONV_SET_TRANSLITERATE, &iconv_param);
     iconv_param = 1;


### PR DESCRIPTION
iconvctl is only defined in GNU libiconv so check for the availability
of this function before using it

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>