### PR TITLE
Allows space in URI until the last space

### DIFF
--- a/htp/htp_request_generic.c
+++ b/htp/htp_request_generic.c
@@ -331,25 +331,29 @@ htp_status_t htp_parse_request_line_generic_ex(htp_connp_t *connp, int nul_termi
 
     start = pos;
     bad_delim = 0;
+    pos = len - 1;
 
-    // The URI ends with the first whitespace.
-    while ((pos < len) && (data[pos] != 0x20)) {
+    // Skips the spaces at the end of line (after protocol)
+    while (pos > start && htp_is_space(data[pos])) pos--;
+    // The URI ends with the last whitespace.
+    while ((pos > start) && (data[pos] != 0x20)) {
         if (!bad_delim && htp_is_space(data[pos])) {
             bad_delim++;
         }
-        pos++;
+        pos--;
     }
     /* if we've seen some 'bad' delimiters, we retry with those */
-    if (bad_delim && pos == len) {
+    if (bad_delim && pos == start) {
         // special case: even though RFC's allow only SP (0x20), many
         // implementations allow other delimiters, like tab or other
         // characters that isspace() accepts.
-        pos = start;
         while ((pos < len) && (!htp_is_space(data[pos]))) pos++;
     }
     if (bad_delim) {
         // warn regardless if we've seen non-compliant chars
         htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Request line: URI contains non-compliant delimiter");
+    } else if (pos == start) {
+            pos = len;
     }
 
     tx->request_uri = bstr_dup_mem(data + start, pos - start);


### PR DESCRIPTION
Fixes #2881

It is less likely that spaces are added in protocol than in URIs

Follows #197 :
- Allows whitespace between protocol and end of line