### PR TITLE
Adds htp_parse_content_range function

### DIFF
--- a/htp/htp.h
+++ b/htp/htp.h
@@ -602,6 +602,32 @@ struct htp_uri_t {
 };
 
 /**
+ * Content-range structure. Where an element is not present, the
+ * corresponding field will be set to NULL or -1, depending on the
+ * field type.
+ */
+struct htp_content_range_t {
+    /** Start offset. */
+    int64_t start;
+
+    /** End offset. */
+    int64_t end;
+
+    /** Total size. */
+    int64_t size;
+};
+
+/**
+ * Performs parsing of the content-range value
+ *
+ * @param[in] rawvalue
+ * @param[out] range
+ *
+ * @return HTP_OK on success, HTP_ERROR on failure.
+ */
+htp_status_t htp_parse_content_range(bstr * rawvalue, htp_content_range_t *range);
+
+/**
  * Frees all data contained in the uri, and then the uri itself.
  * 
  * @param[in] uri

--- a/htp/htp_core.h
+++ b/htp/htp_core.h
@@ -57,6 +57,7 @@ typedef struct htp_param_t htp_param_t;
 typedef struct htp_tx_data_t htp_tx_data_t;
 typedef struct htp_tx_t htp_tx_t;
 typedef struct htp_uri_t htp_uri_t;
+typedef struct htp_content_range_t htp_content_range_t;
 typedef struct timeval htp_time_t;
 
 // Below are all htp_status_t return codes used by LibHTP. Enum is not


### PR DESCRIPTION
Fixes #2485

See https://github.com/OISF/suricata/pull/3773

This is a proposal.
Here are some open questions 
- Is libhtp the right place for this (or should we do this in suricata) ?
- Should a `htp_content_range_t` field be added to `htp_tx_t` ? (and be parsed automatically depending on configuration)
- How should we test it ?