### PR TITLE
headers: limits to 32 the repetitions of a header

### DIFF
--- a/htp/htp_core.h
+++ b/htp/htp_core.h
@@ -230,6 +230,8 @@ enum htp_file_source_t {
 #define HTP_REQUEST_INVALID_C_L            0x200000000ULL
 #define HTP_AUTH_INVALID                   0x400000000ULL
 
+#define HTP_MAX_HEADERS_REPETITIONS 32
+
 #define HTP_HOST_INVALID ( HTP_HOSTU_INVALID | HTP_HOSTH_INVALID )
 
 // Logging-related constants.

--- a/htp/htp_response_generic.c
+++ b/htp/htp_response_generic.c
@@ -256,8 +256,22 @@ htp_status_t htp_process_response_header_generic(htp_connp_t *connp, unsigned ch
     htp_header_t *h_existing = htp_table_get(connp->out_tx->response_headers, h->name);
     if (h_existing != NULL) {
         // Keep track of repeated same-name headers.
+        if ((h_existing->flags & HTP_FIELD_REPEATED) == 0) {
+            // This is the second occurence for this header.
+            htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Repetition for header");
+        } else {
+            // Hacky : we use most significant bytes
+            // to count the number of header repetitions
+            uint32_t repetitions = h_existing->flags >> 32;
+            if (repetitions > HTP_MAX_HEADERS_REPETITIONS) {
+                bstr_free(h->name);
+                bstr_free(h->value);
+                free(h);
+                return HTP_OK;
+            }
+        }
         h_existing->flags |= HTP_FIELD_REPEATED;
-                
+
         // Having multiple C-L headers is against the RFC but many
         // browsers ignore the subsequent headers if the values are the same.
         if (bstr_cmp_c_nocase(h->name, "Content-Length") == 0) {


### PR DESCRIPTION
Follows #188 

Modified : 
- Allows up to 64 repetitions of a header before dropping the contents

Here are my comments on the chosen solutions and other ones :
I chose the ugly solution to hack `flags` field to use some of it as a counter of repetitions.
Other solution would have been
- add a specific field in `htp_header_t` in htp.h : but it seemed bad to change the API
- make libhtp use a inner structure same as `htp_header_t` with the repetitions counter : this seemed to big a change

We could also make `HTP_MAX_HEADERS_REPETITIONS` to be configurable