### PR TITLE
headers: warns on first duplication of header

### DIFF
--- a/htp/htp.h
+++ b/htp/htp.h
@@ -536,6 +536,9 @@ struct htp_tx_t {
 
     /** Transaction index on the connection. */
     size_t index;
+
+    /** Total repetitions for headers. */
+    uint32_t header_repetitions;
 };
 
 /**

--- a/htp/htp_core.h
+++ b/htp/htp_core.h
@@ -230,6 +230,8 @@ enum htp_file_source_t {
 #define HTP_REQUEST_INVALID_C_L            0x200000000ULL
 #define HTP_AUTH_INVALID                   0x400000000ULL
 
+#define HTP_MAX_HEADERS_REPETITIONS 64
+
 #define HTP_HOST_INVALID ( HTP_HOSTU_INVALID | HTP_HOSTH_INVALID )
 
 // Logging-related constants.

--- a/htp/htp_request_generic.c
+++ b/htp/htp_request_generic.c
@@ -70,6 +70,22 @@ htp_status_t htp_process_request_header_generic(htp_connp_t *connp, unsigned cha
     if (h_existing != NULL) {
         // TODO Do we want to have a list of the headers that are
         //      allowed to be combined in this way?
+        if ((h_existing->flags & HTP_FIELD_REPEATED) == 0) {
+            // This is the second occurence for this header.
+            htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Repetition for header");
+        } else {
+            // For simplicity reasons, we count the repetitions of all headers
+            if (connp->in_tx->header_repetitions < HTP_MAX_HEADERS_REPETITIONS) {
+                connp->in_tx->header_repetitions++;
+            } else {
+                bstr_free(h->name);
+                bstr_free(h->value);
+                free(h);
+                return HTP_OK;
+            }
+        }
+        // Keep track of repeated same-name headers.
+        h_existing->flags |= HTP_FIELD_REPEATED;
 
         // Add to the existing header.
         bstr *new_value = bstr_expand(h_existing->value, bstr_len(h_existing->value) + 2 + bstr_len(h->value));
@@ -88,9 +104,6 @@ htp_status_t htp_process_request_header_generic(htp_connp_t *connp, unsigned cha
         bstr_free(h->name);
         bstr_free(h->value);
         free(h);
-
-        // Keep track of repeated same-name headers.
-        h_existing->flags |= HTP_FIELD_REPEATED;
     } else {
         // Add as a new header.
         if (htp_table_add(connp->in_tx->request_headers, h->name, h) != HTP_OK) {

--- a/htp/htp_response_generic.c
+++ b/htp/htp_response_generic.c
@@ -256,8 +256,22 @@ htp_status_t htp_process_response_header_generic(htp_connp_t *connp, unsigned ch
     htp_header_t *h_existing = htp_table_get(connp->out_tx->response_headers, h->name);
     if (h_existing != NULL) {
         // Keep track of repeated same-name headers.
+        if ((h_existing->flags & HTP_FIELD_REPEATED) == 0) {
+            // This is the second occurence for this header.
+            htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Repetition for header");
+        } else {
+            // For simplicity reasons, we count the repetitions of all headers
+            if (connp->out_tx->header_repetitions < HTP_MAX_HEADERS_REPETITIONS) {
+                connp->out_tx->header_repetitions++;
+            } else {
+                bstr_free(h->name);
+                bstr_free(h->value);
+                free(h);
+                return HTP_OK;
+            }
+        }
         h_existing->flags |= HTP_FIELD_REPEATED;
-                
+
         // Having multiple C-L headers is against the RFC but many
         // browsers ignore the subsequent headers if the values are the same.
         if (bstr_cmp_c_nocase(h->name, "Content-Length") == 0) {


### PR DESCRIPTION
Limits to 64 the number of total repetitions
Drops headers contents afterwards
Adds header_repetitions field to htp_tx_t

Follows #205 

Modified :
- use a counter in `htp_tx_t` instead of hacking `flags`

The counter is global per the transaction.
Ie if in one transaction, header a is repeated 30 times, and then header b is repeated 40 times, we will drop the last headers b even if 40 is less than 64...