### PR TITLE
Allows space in URI until the last space

### DIFF
--- a/htp/htp_config.c
+++ b/htp/htp_config.c
@@ -158,6 +158,7 @@ htp_cfg_t *htp_config_create(void) {
     cfg->extract_request_files = 0;
     cfg->extract_request_files_limit = -1; // Use the parser default.
     cfg->response_decompression_layer_limit = 2; // 2 layers seem fairly common
+    cfg->allow_space_uri = 0;
 
     // Default settings for URL-encoded data.
 
@@ -525,6 +526,11 @@ void htp_config_set_parse_request_cookies(htp_cfg_t *cfg, int parse_request_cook
 void htp_config_set_response_decompression(htp_cfg_t *cfg, int enabled) {
     if (cfg == NULL) return;
     cfg->response_decompression_enabled = enabled;
+}
+
+void htp_config_set_allow_space_uri(htp_cfg_t *cfg, int allow_space_uri) {
+    if (cfg == NULL) return;
+    cfg->allow_space_uri = allow_space_uri;
 }
 
 int htp_config_set_server_personality(htp_cfg_t *cfg, enum htp_server_personality_t personality) {

--- a/htp/htp_config.h
+++ b/htp/htp_config.h
@@ -491,6 +491,14 @@ void htp_config_set_parse_request_auth(htp_cfg_t *cfg, int parse_request_auth);
 void htp_config_set_parse_request_cookies(htp_cfg_t *cfg, int parse_request_cookies);
 
 /**
+ * Enable or disable spaces in URIs. Disabled by default.
+ *
+ * @param[in] cfg
+ * @param[in] allow_space_uri
+ */
+void htp_config_set_allow_space_uri(htp_cfg_t *cfg, int allow_space_uri);
+
+/**
  * Configures whether consecutive path segment separators will be compressed. When enabled, a path
  * such as "/one//two" will be normalized to "/one/two". Backslash conversion and path segment separator
  * decoding are carried out before compression. For example, the path "/one\\/two\/%5cthree/%2f//four"

--- a/htp/htp_config_private.h
+++ b/htp/htp_config_private.h
@@ -193,6 +193,9 @@ struct htp_cfg_t {
     /** How many extracted files are allowed in a single Multipart request? */
     int extract_request_files_limit;
 
+    /** Whether to allow spaces in URI. */
+    int allow_space_uri;
+
     /** The location on disk where temporary files will be created. */
     char *tmpdir;
 

--- a/htp/htp_request_generic.c
+++ b/htp/htp_request_generic.c
@@ -331,25 +331,50 @@ htp_status_t htp_parse_request_line_generic_ex(htp_connp_t *connp, int nul_termi
 
     start = pos;
     bad_delim = 0;
-
-    // The URI ends with the first whitespace.
-    while ((pos < len) && (data[pos] != 0x20)) {
-        if (!bad_delim && htp_is_space(data[pos])) {
-            bad_delim++;
+    if (tx->connp->cfg->allow_space_uri) {
+        pos = len - 1;
+        // Skips the spaces at the end of line (after protocol)
+        while (pos > start && htp_is_space(data[pos])) pos--;
+        // The URI ends with the last whitespace.
+        while ((pos > start) && (data[pos] != 0x20)) {
+            if (!bad_delim && htp_is_space(data[pos])) {
+                bad_delim++;
+            }
+            pos--;
         }
-        pos++;
-    }
-    /* if we've seen some 'bad' delimiters, we retry with those */
-    if (bad_delim && pos == len) {
-        // special case: even though RFC's allow only SP (0x20), many
-        // implementations allow other delimiters, like tab or other
-        // characters that isspace() accepts.
-        pos = start;
-        while ((pos < len) && (!htp_is_space(data[pos]))) pos++;
-    }
-    if (bad_delim) {
-        // warn regardless if we've seen non-compliant chars
-        htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Request line: URI contains non-compliant delimiter");
+        /* if we've seen some 'bad' delimiters, we retry with those */
+        if (bad_delim && pos == start) {
+            // special case: even though RFC's allow only SP (0x20), many
+            // implementations allow other delimiters, like tab or other
+            // characters that isspace() accepts.
+            while ((pos < len) && (!htp_is_space(data[pos]))) pos++;
+        }
+        if (bad_delim) {
+            // warn regardless if we've seen non-compliant chars
+            htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Request line: URI contains non-compliant delimiter");
+        } else if (pos == start) {
+            pos = len;
+        }
+    } else {
+        // The URI ends with the first whitespace.
+        while ((pos < len) && (data[pos] != 0x20)) {
+            if (!bad_delim && htp_is_space(data[pos])) {
+                bad_delim++;
+            }
+            pos++;
+        }
+        /* if we've seen some 'bad' delimiters, we retry with those */
+        if (bad_delim && pos == len) {
+            // special case: even though RFC's allow only SP (0x20), many
+            // implementations allow other delimiters, like tab or other
+            // characters that isspace() accepts.
+            pos = start;
+            while ((pos < len) && (!htp_is_space(data[pos]))) pos++;
+        }
+        if (bad_delim) {
+            // warn regardless if we've seen non-compliant chars
+            htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Request line: URI contains non-compliant delimiter");
+        }
     }
 
     tx->request_uri = bstr_dup_mem(data + start, pos - start);


### PR DESCRIPTION
Fixes #2881

It is less likely that spaces are added in protocol than in URIs

Modifies #203 :
- Behavior is configurable (and disabled by default)
- Fix indent