### PR TITLE
Fuzzcallbacks v1

### DIFF
--- a/htp/htp_private.h
+++ b/htp/htp_private.h
@@ -60,6 +60,7 @@ extern "C" {
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#include "htp_config_auto_gen.h"
 #include "htp.h"
 #include "htp_config_private.h"
 #include "htp_connection_parser_private.h"

--- a/test/fuzz/fuzz_htp.c
+++ b/test/fuzz/fuzz_htp.c
@@ -38,12 +38,18 @@ static int HTPCallbackResponse(htp_tx_t *out_tx) {
 static int HTPCallbackRequestHeaderData(htp_tx_data_t *tx_data)
 {
     fprintf(logfile, "HTPCallbackRequestHeaderData %"PRIuMAX"\n", (uintmax_t)tx_data->len);
+    if (tx_data->len > 0) {
+        fprintf(logfile, "HTPCallbackRequestHeaderData %x %x\n", tx_data->data[0], tx_data->data[(uintmax_t)tx_data->len-1]);
+    }
     return 0;
 }
 
 static int HTPCallbackResponseHeaderData(htp_tx_data_t *tx_data)
 {
     fprintf(logfile, "HTPCallbackResponseHeaderData %"PRIuMAX"\n", (uintmax_t)tx_data->len);
+    if (tx_data->len > 0) {
+        fprintf(logfile, "HTPCallbackResponseHeaderData %x %x\n", tx_data->data[0], tx_data->data[(uintmax_t)tx_data->len-1]);
+    }
     return 0;
 }
 
@@ -62,12 +68,18 @@ static int HTPCallbackResponseHasTrailer(htp_tx_t *tx)
 static int HTPCallbackRequestBodyData(htp_tx_data_t *tx_data)
 {
     fprintf(logfile, "HTPCallbackRequestBodyData %"PRIuMAX"\n", (uintmax_t)tx_data->len);
+    if (tx_data->len > 0) {
+        fprintf(logfile, "HTPCallbackRequestBodyData %x %x\n", tx_data->data[0], tx_data->data[(uintmax_t)tx_data->len-1]);
+    }
     return 0;
 }
 
 static int HTPCallbackResponseBodyData(htp_tx_data_t *tx_data)
 {
     fprintf(logfile, "HTPCallbackResponseBodyData %"PRIuMAX"\n", (uintmax_t)tx_data->len);
+    if (tx_data->len > 0) {
+        fprintf(logfile, "HTPCallbackResponseBodyData %x %x\n", tx_data->data[0], tx_data->data[(uintmax_t)tx_data->len-1]);
+    }
     return 0;
 }
 


### PR DESCRIPTION
First commit is about compiling easily libhtp (I can provide my CMakeLists.txt files if you wish)

Second commit is extending the fuzz targets so that the callbacks with buffers returned from libhtp will check if the buffers are valid (ie if we do not overflow).
@victorjulien this follows our mail about ASAN triggered suricata.