### PR TITLE
htp: better format strings for int64_t

### DIFF
--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -419,7 +419,7 @@ htp_status_t htp_connp_RES_BODY_CHUNKED_LENGTH(htp_connp_t *connp) {
                 connp->out_tx->response_transfer_coding = HTP_CODING_IDENTITY;
 
                 htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
-                        "Response chunk encoding: Invalid chunk length: %d",
+                        "Response chunk encoding: Invalid chunk length: "PRId64"",
                         connp->out_chunked_length);
                 return HTP_OK;
             }
@@ -671,7 +671,7 @@ htp_status_t htp_connp_RES_BODY_DETERMINE(htp_connp_t *connp) {
             // Get body length
             connp->out_tx->response_content_length = htp_parse_content_length(cl->value);
             if (connp->out_tx->response_content_length < 0) {
-                htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0, "Invalid C-L field in response: %d",
+                htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0, "Invalid C-L field in response: "PRId64"",
                         connp->out_tx->response_content_length);
                 return HTP_ERROR;
             } else {


### PR DESCRIPTION
Depending on the system and the compiler, we can have a warning about `%d` not be a good format string fit for `int64_t`
Let's use the macro `PRId64`
Thanks https://stackoverflow.com/questions/9225567/how-to-print-a-int64-t-type-in-c