### PR TITLE
libhtp: remove direct fprintf to stderr

### DIFF
--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -329,7 +329,6 @@ htp_status_t htp_connp_REQ_CONNECT_PROBE_DATA(htp_connp_t *connp) {
     unsigned char *data;
     size_t len;
     if (htp_connp_req_consolidate_data(connp, &data, &len) != HTP_OK) {
-        fprintf(stderr, "htp_connp_req_consolidate_data fail");
         return HTP_ERROR;
     }
 #ifdef HTP_DEBUG


### PR DESCRIPTION
Found by oss-fuzz

Libhtp should not use directly fprintf in normal mode (but htp_log)
This is the only case in whole corpus