### PR TITLE
Fuzzperf v1

### DIFF
--- a/htp/htp_list.c
+++ b/htp/htp_list.c
@@ -42,6 +42,22 @@
 
 // Array-backed list
 
+htp_status_t htp_list_array_init(htp_list_t *l, size_t size) {
+    // Allocate the initial batch of elements.
+    l->elements = malloc(size * sizeof (void *));
+    if (l->elements == NULL) {
+        return HTP_ERROR;
+    }
+
+    // Initialize the structure.
+    l->first = 0;
+    l->last = 0;
+    l->current_size = 0;
+    l->max_size = size;
+
+    return HTP_OK;
+}
+
 htp_list_t *htp_list_array_create(size_t size) {
     // It makes no sense to create a zero-size list.
     if (size == 0) return NULL;
@@ -50,18 +66,10 @@ htp_list_t *htp_list_array_create(size_t size) {
     htp_list_array_t *l = calloc(1, sizeof (htp_list_array_t));
     if (l == NULL) return NULL;
 
-    // Allocate the initial batch of elements.
-    l->elements = malloc(size * sizeof (void *));
-    if (l->elements == NULL) {
+    if (htp_list_array_init(l, size) == HTP_ERROR) {
         free(l);
         return NULL;
     }
-
-    // Initialize the structure.
-    l->first = 0;
-    l->last = 0;
-    l->current_size = 0;
-    l->max_size = size;
 
     return (htp_list_t *) l;
 }
@@ -80,6 +88,12 @@ void htp_list_array_destroy(htp_list_array_t *l) {
 
     free(l->elements);
     free(l);
+}
+
+void htp_list_array_release(htp_list_array_t *l) {
+    if (l == NULL) return;
+
+    free(l->elements);
 }
 
 void *htp_list_array_get(const htp_list_array_t *l, size_t idx) {

--- a/htp/htp_list.h
+++ b/htp/htp_list.h
@@ -48,8 +48,10 @@ extern "C" {
 #define htp_list_t htp_list_array_t
 #define htp_list_add htp_list_array_push
 #define htp_list_create htp_list_array_create
+#define htp_list_init htp_list_array_init
 #define htp_list_clear htp_list_array_clear
 #define htp_list_destroy htp_list_array_destroy
+#define htp_list_release htp_list_array_release
 #define htp_list_get htp_list_array_get
 #define htp_list_pop htp_list_array_pop
 #define htp_list_push htp_list_array_push
@@ -76,6 +78,15 @@ typedef struct htp_list_linked_t htp_list_linked_t;
 htp_list_array_t *htp_list_array_create(size_t size);
 
 /**
+ * Initialize an array-backed list.
+ *
+ * @param[in] l
+ * @param[in] size
+ * @return HTP_OK or HTP_ERROR if allocation failed
+ */
+htp_status_t htp_list_array_init(htp_list_array_t *l, size_t size);
+
+/**
  * Remove all elements from the list. It is the responsibility of the caller
  * to iterate over list elements and deallocate them if necessary, prior to
  * invoking this function.
@@ -91,6 +102,15 @@ void htp_list_array_clear(htp_list_array_t *l);
  * @param[in] l
  */
 void htp_list_array_destroy(htp_list_array_t *l);
+
+/**
+ * Free the memory occupied by this list, except itself.
+ * This function assumes the elements held by the list
+ * were freed beforehand.
+ *
+ * @param[in] l
+ */
+void htp_list_array_release(htp_list_array_t *l);
 
 /**
  * Find the element at the given index.

--- a/htp/htp_request_generic.c
+++ b/htp/htp_request_generic.c
@@ -343,9 +343,12 @@ htp_status_t htp_parse_request_line_generic_ex(htp_connp_t *connp, int nul_termi
         }
         pos++;
     }
+// Too much performance overhead for fuzzing
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (bad_delim) {
         htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Request line: non-compliant delimiter between Method and URI");
     }
+#endif
 
     // Is there anything after the request method?
     if (pos == len) {
@@ -375,10 +378,13 @@ htp_status_t htp_parse_request_line_generic_ex(htp_connp_t *connp, int nul_termi
         pos = start;
         while ((pos < len) && (!htp_is_space(data[pos]))) pos++;
     }
+// Too much performance overhead for fuzzing
+#ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     if (bad_delim) {
         // warn regardless if we've seen non-compliant chars
         htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Request line: URI contains non-compliant delimiter");
     }
+#endif
 
     tx->request_uri = bstr_dup_mem(data + start, pos - start);
     if (tx->request_uri == NULL) return HTP_ERROR;

--- a/htp/htp_table_private.h
+++ b/htp/htp_table_private.h
@@ -62,7 +62,7 @@ enum htp_table_alloc_t {
 
 struct htp_table_t {
     /** Table key and value pairs are stored in this list; name first, then value. */
-    htp_list_t *list;
+    htp_list_t list;
 
     /**
      * Key management strategy. Initially set to HTP_TABLE_KEYS_ALLOC_UKNOWN. The


### PR DESCRIPTION
These two commits come from profiling libhtp with corpus from oss-fuzz

Out of the 596112 logs produced, we have the top 3 :
- 22008 Invalid response line: invalid protocol
- 133877 Request line: non-compliant delimiter between Method and URI
- 353607 Request line: URI contains non-compliant delimiter

So, I propose to disable the first two and get rid of around 80% of the logs 
My profiling shows that we go from 7.5 seconds to 6.5 seconds with this change on the corpus

The other change is using directly `htp_list_t` in `htp_table_t` instead of a pointer to it (thus avoiding one alloc/free)
That is a gain of about 0.15 seconds for my profiling
