### PR TITLE
deadcode: removes some unused functions

### DIFF
--- a/htp/bstr.c
+++ b/htp/bstr.c
@@ -51,14 +51,6 @@ bstr *bstr_alloc(size_t len) {
     return b;
 }
 
-bstr *bstr_add(bstr *destination, const bstr *source) {
-    return bstr_add_mem(destination, bstr_ptr(source), bstr_len(source));
-}
-
-bstr *bstr_add_c(bstr *bdestination, const char *csource) {
-    return bstr_add_mem(bdestination, csource, strlen(csource));
-}
-
 bstr *bstr_add_c_noex(bstr *destination, const char *source) {
     return bstr_add_mem_noex(destination, source, strlen(source));
 }
@@ -103,16 +95,8 @@ void bstr_adjust_len(bstr *b, size_t newlen) {
     b->len = newlen;
 }
 
-void bstr_adjust_realptr(bstr *b, void *newrealptr) {
-    b->realptr = newrealptr;
-}
-
 void bstr_adjust_size(bstr *b, size_t newsize) {
     b->size = newsize;
-}
-
-int bstr_begins_with(const bstr *haystack, const bstr *needle) {
-    return bstr_begins_with_mem(haystack, bstr_ptr(needle), bstr_len(needle));
 }
 
 int bstr_begins_with_c(const bstr *haystack, const char *needle) {
@@ -121,10 +105,6 @@ int bstr_begins_with_c(const bstr *haystack, const char *needle) {
 
 int bstr_begins_with_c_nocase(const bstr *haystack, const char *needle) {
     return bstr_begins_with_mem_nocase(haystack, needle, strlen(needle));
-}
-
-int bstr_begins_with_nocase(const bstr *haystack, const bstr *needle) {
-    return bstr_begins_with_mem_nocase(haystack, bstr_ptr(needle), bstr_len(needle));
 }
 
 int bstr_begins_with_mem(const bstr *haystack, const void *_data, size_t len) {
@@ -207,10 +187,6 @@ int bstr_chr(const bstr *b, int c) {
     return -1;
 }
 
-int bstr_cmp(const bstr *b1, const bstr *b2) {
-    return bstr_util_cmp_mem(bstr_ptr(b1), bstr_len(b1), bstr_ptr(b2), bstr_len(b2));
-}
-
 int bstr_cmp_c(const bstr *b, const char *c) {
     return bstr_util_cmp_mem(bstr_ptr(b), bstr_len(b), c, strlen(c));
 }
@@ -283,10 +259,6 @@ void bstr_free(bstr *b) {
     free(b);
 }
 
-int bstr_index_of(const bstr *haystack, const bstr *needle) {
-    return bstr_index_of_mem(haystack, bstr_ptr(needle), bstr_len(needle));
-}
-
 int bstr_index_of_c(const bstr *haystack, const char *needle) {
     return bstr_index_of_mem(haystack, needle, strlen(needle));
 }
@@ -301,26 +273,6 @@ int bstr_index_of_mem(const bstr *haystack, const void *_data2, size_t len2) {
 
 int bstr_index_of_mem_nocase(const bstr *haystack, const void *_data2, size_t len2) {
     return bstr_util_mem_index_of_mem_nocase(bstr_ptr(haystack), bstr_len(haystack), _data2, len2);
-}
-
-int bstr_index_of_nocase(const bstr *haystack, const bstr *needle) {
-    return bstr_index_of_mem_nocase(haystack, bstr_ptr(needle), bstr_len(needle));
-}
-
-int bstr_rchr(const bstr *b, int c) {
-    const unsigned char *data = bstr_ptr(b);
-    size_t len = bstr_len(b);
-
-    size_t i = len;
-    while (i > 0) {
-        if (data[i - 1] == c) {
-            return i - 1;
-        }
-
-        i--;
-    }
-
-    return -1;
 }
 
 bstr *bstr_to_lowercase(bstr *b) {
@@ -550,10 +502,6 @@ char *bstr_util_memdup_to_c(const void *_data, size_t len) {
 char *bstr_util_strdup_to_c(const bstr *b) {
     if (b == NULL) return NULL;
     return bstr_util_memdup_to_c(bstr_ptr(b), bstr_len(b));
-}
-
-bstr *bstr_wrap_c(const char *cstr) {
-    return bstr_wrap_mem((unsigned char *) cstr, strlen(cstr));
 }
 
 bstr *bstr_wrap_mem(const void *data, size_t len) {

--- a/htp/bstr.h
+++ b/htp/bstr.h
@@ -83,30 +83,6 @@ struct bstr_t {
 // Functions
 
 /**
- * Append source bstring to destination bstring, growing destination if
- * necessary. If the destination bstring is expanded, the pointer will change.
- * You must replace the original destination pointer with the returned one.
- * Destination is not changed on memory allocation failure.
- *
- * @param[in] bdestination
- * @param[in] bsource
- * @return Updated bstring, or NULL on memory allocation failure.
- */
-bstr *bstr_add(bstr *bdestination, const bstr *bsource);
-
-/**
- * Append a NUL-terminated source to destination, growing destination if
- * necessary. If the string is expanded, the pointer will change. You must 
- * replace the original destination pointer with the returned one. Destination
- * is not changed on memory allocation failure.
- *
- * @param[in] b
- * @param[in] cstr
- * @return Updated bstring, or NULL on memory allocation failure.
- */
-bstr *bstr_add_c(bstr *b, const char *cstr);
-
-/**
  * Append as many bytes from the source to destination bstring. The
  * destination storage will not be expanded if there is not enough space in it
  * already to accommodate all of the data.
@@ -164,15 +140,6 @@ bstr *bstr_add_noex(bstr *bdestination, const bstr *bsource);
 void bstr_adjust_len(bstr *b, size_t newlen);
 
 /**
- * Change the external pointer used by bstring. You will need to use this
- * function only if you're messing with bstr internals. Use with caution.
- *
- * @param[in] b
- * @param[in] newrealptr
- */
-void bstr_adjust_realptr(bstr *b, void *newrealptr);
-
-/**
  * Adjust bstring size. This does not change the size of the storage behind
  * the bstring, just changes the field that keeps track of how many bytes
  * there are in the storage. You will need to use this function only if
@@ -190,15 +157,6 @@ void bstr_adjust_size(bstr *b, size_t newsize);
  * @return New string instance
  */
 bstr *bstr_alloc(size_t size);
-
-/**
- * Checks whether bstring begins with another bstring. Case sensitive.
- * 
- * @param[in] bhaystack
- * @param[in] bneedle
- * @return 1 if true, otherwise 0.
- */
-int bstr_begins_with(const bstr *bhaystack, const bstr *bneedle);
 
 /**
  * Checks whether bstring begins with NUL-terminated string. Case sensitive.
@@ -239,15 +197,6 @@ int bstr_begins_with_mem(const bstr *bhaystack, const void *data, size_t len);
 int bstr_begins_with_mem_nocase(const bstr *bhaystack, const void *data, size_t len);
 
 /**
- * Checks whether bstring begins with another bstring. Case insensitive.
- *
- * @param[in] bhaystack
- * @param[in] cneedle
- * @return 1 if true, otherwise 0.
- */
-int bstr_begins_with_nocase(const bstr *bhaystack, const bstr *cneedle);
-
-/**
  * Return the byte at the given position.
  *
  * @param[in] b
@@ -284,16 +233,6 @@ void bstr_chop(bstr *b);
  */
 int bstr_chr(const bstr *b, int c);
 
-/**
- * Case-sensitive comparison of two bstrings.
- *
- * @param[in] b1
- * @param[in] b2
- * @return Zero on string match, 1 if b1 is greater than b2, and -1 if b2 is
- *         greater than b1.
- */
-int bstr_cmp(const bstr *b1, const bstr *b2);
-  
 /**
  * Case-sensitive comparison of a bstring and a NUL-terminated string.
  *
@@ -408,24 +347,6 @@ bstr *bstr_expand(bstr *b, size_t newsize);
 void bstr_free(bstr *b);
 
 /**
- * Find the needle in the haystack.
- *
- * @param[in] bhaystack
- * @param[in] bneedle
- * @return Position of the match, or -1 if the needle could not be found.
- */
-int bstr_index_of(const bstr *bhaystack, const bstr *bneedle);
-
-/**
- * Find the needle in the haystack, ignoring case differences.
- *
- * @param[in] bhaystack
- * @param[in] bneedle
- * @return Position of the match, or -1 if the needle could not be found.
- */
-int bstr_index_of_nocase(const bstr *bhaystack, const bstr *bneedle);
-
-/**
  * Find the needle in the haystack, with the needle being a NUL-terminated
  * string.
  *
@@ -465,15 +386,6 @@ int bstr_index_of_mem(const bstr *bhaystack, const void *data, size_t len);
  * @return Position of the match, or -1 if the needle could not be found.
  */
 int bstr_index_of_mem_nocase(const bstr *bhaystack, const void *data, size_t len);
-
-/**
- * Return the last position of a character (byte).
- *
- * @param[in] b
- * @param[in] c
- * @return The last position of the character, or -1 if it could not be found.
- */
-int bstr_rchr(const bstr *b, int c);
 
 /**
  * Convert bstring to lowercase. This function converts the supplied string,
@@ -597,16 +509,6 @@ char *bstr_util_memdup_to_c(const void *data, size_t len);
  *         allocation failure.
  */
 char *bstr_util_strdup_to_c(const bstr *b);
-  
-/**
- * Create a new bstring from the provided NUL-terminated string and without
- * copying the data. The caller must ensure that the input string continues
- * to point to a valid memory location for as long as the bstring is used.
- * 
- * @param[in] cstr
- * @return New bstring, or NULL on memory allocation failure.
- */
-bstr *bstr_wrap_c(const char *cstr);
 
 /**
  * Create a new bstring from the provided memory buffer without

--- a/htp/htp_base64.c
+++ b/htp/htp_base64.c
@@ -160,16 +160,6 @@ int htp_base64_decode(htp_base64_decoder *decoder, const void *_code_in, int len
 }
 
 /**
- * Base64-decode input, given as bstring.
- *
- * @param[in] input
- * @return new base64-decoded bstring
- */
-bstr *htp_base64_decode_bstr(bstr *input) {
-    return htp_base64_decode_mem(bstr_ptr(input), bstr_len(input));
-}
-
-/**
  * Base64-decode input, given as memory range.
  *
  * @param[in] data

--- a/htp/htp_base64.h
+++ b/htp/htp_base64.h
@@ -62,8 +62,6 @@ int htp_base64_decode_single(signed char value_in);
 
 int htp_base64_decode(htp_base64_decoder *decoder, const void *code_in, int length_in, void *plaintext_out, int length_out);
 
-bstr *htp_base64_decode_bstr(bstr *input);
-
 bstr *htp_base64_decode_mem(const void *data, size_t len);
 
 #ifdef __cplusplus

--- a/htp/htp_connection_parser.c
+++ b/htp/htp_connection_parser.c
@@ -40,10 +40,6 @@
 
 #include "htp_private.h"
 
-void htp_connp_clear_error(htp_connp_t *connp) {
-    connp->last_error = NULL;
-}
-
 void htp_connp_close(htp_connp_t *connp, const htp_time_t *timestamp) {
     if (connp == NULL) return;
     

--- a/htp/htp_connection_parser.h
+++ b/htp/htp_connection_parser.h
@@ -44,13 +44,6 @@ extern "C" {
 #endif
 
 /**
- * Clears the most recent error, if any.
- *
- * @param[in] connp
- */
-void htp_connp_clear_error(htp_connp_t *connp);
-
-/**
  * Closes the connection associated with the supplied parser.
  *
  * @param[in] connp

--- a/htp/htp_hooks.c
+++ b/htp/htp_hooks.c
@@ -136,25 +136,3 @@ htp_status_t htp_hook_run_all(htp_hook_t *hook, void *user_data) {
 
     return HTP_OK;
 }
-
-htp_status_t htp_hook_run_one(htp_hook_t *hook, void *user_data) {
-    if (hook == NULL) return HTP_DECLINED;
-
-    for (size_t i = 0, n = htp_list_size(hook->callbacks); i < n; i++) {
-        htp_callback_t *callback = htp_list_get(hook->callbacks, i);
-
-        htp_status_t rc = callback->fn(user_data);
-
-        // A hook can return HTP_DECLINED to say that it did no work,
-        // and we'll ignore that. If we see HTP_OK or anything else,
-        // we stop processing (because it was either a successful
-        // handling or an error).
-        if (rc != HTP_DECLINED) {
-            // Return HTP_OK or an error.
-            return rc;
-        }
-    }
-
-    // No hook wanted to process the callback.
-    return HTP_DECLINED;
-}

--- a/htp/htp_hooks.h
+++ b/htp/htp_hooks.h
@@ -104,17 +104,6 @@ htp_status_t htp_hook_register(htp_hook_t **hook, const htp_callback_fn_t callba
  */
 htp_status_t htp_hook_run_all(htp_hook_t *hook, void *user_data);
 
-/**
- * Run callbacks one by one until one of them accepts to service the hook.
- *
- * @param[in] hook
- * @param[in] user_data
- * @return HTP_OK if a hook was found to process the callback, HTP_DECLINED if
- *         no hook could be found, HTP_STOP if a hook signalled the processing
- *         to stop, and HTP_ERROR or any other value less than zero on error.
- */
-htp_status_t htp_hook_run_one(htp_hook_t *hook, void *user_data);
-
 #ifdef __cplusplus
 }
 #endif

--- a/htp/htp_list.c
+++ b/htp/htp_list.c
@@ -197,26 +197,6 @@ size_t htp_list_array_size(const htp_list_array_t *l) {
     return l->current_size;
 }
 
-void *htp_list_array_shift(htp_list_array_t *l) {
-    if (l == NULL) return NULL;
-
-    void *r = NULL;
-
-    if (l->current_size == 0) {
-        return NULL;
-    }
-
-    r = l->elements[l->first];
-    l->first++;
-    if (l->first == l->max_size) {
-        l->first = 0;
-    }
-
-    l->current_size--;
-
-    return r;
-}
-
 #if 0
 // Linked list
 
@@ -320,41 +300,5 @@ void *htp_list_linked_shift(htp_list_linked_t *l) {
     free(le);
 
     return r;
-}
-#endif
-
-#if 0
-
-int main(int argc, char **argv) {
-    htp_list_t *q = htp_list_array_create(4);
-
-    htp_list_push(q, "1");
-    htp_list_push(q, "2");
-    htp_list_push(q, "3");
-    htp_list_push(q, "4");
-
-    htp_list_shift(q);
-    htp_list_push(q, "5");
-    htp_list_push(q, "6");
-
-    char *s = NULL;
-    while ((s = (char *) htp_list_pop(q)) != NULL) {
-        printf("Got: %s\n", s);
-    }
-
-    printf("---\n");
-
-    htp_list_push(q, "1");
-    htp_list_push(q, "2");
-    htp_list_push(q, "3");
-    htp_list_push(q, "4");
-
-    while ((s = (char *) htp_list_shift(q)) != NULL) {
-        printf("Got: %s\n", s);
-    }
-
-    free(q);
-
-    return 0;
 }
 #endif

--- a/htp/htp_list.h
+++ b/htp/htp_list.h
@@ -57,7 +57,6 @@ extern "C" {
 #define htp_list_push htp_list_array_push
 #define htp_list_replace htp_list_array_replace
 #define htp_list_size htp_list_array_size
-#define htp_list_shift htp_list_array_shift
 
 // Data structures
 

--- a/htp/htp_private.h
+++ b/htp/htp_private.h
@@ -138,7 +138,6 @@ htp_status_t htp_tx_state_response_complete_ex(htp_tx_t *tx, int hybrid_mode);
 int htp_convert_method_to_number(bstr *);
 int htp_is_lws(int c);
 int htp_is_separator(int c);
-int htp_is_text(int c);
 int htp_is_token(int c);
 int htp_chomp(unsigned char *data, size_t *len);
 int htp_is_space(int c);
@@ -188,8 +187,6 @@ char *htp_connp_in_state_as_string(htp_connp_t *connp);
 char *htp_connp_out_state_as_string(htp_connp_t *connp);
 char *htp_tx_request_progress_as_string(htp_tx_t *tx);
 char *htp_tx_response_progress_as_string(htp_tx_t *tx);
-
-bstr *htp_unparse_uri_noencode(htp_uri_t *uri);
 
 int htp_treat_response_line_as_body(const uint8_t *data, size_t len);
 

--- a/htp/htp_table.c
+++ b/htp/htp_table.c
@@ -139,14 +139,6 @@ void htp_table_clear(htp_table_t *table) {
     htp_list_clear(&table->list);
 }
 
-void htp_table_clear_ex(htp_table_t *table) {
-    if (table == NULL) return;
-
-    // This function does not free table keys.
-
-    htp_list_clear(&table->list);
-}
-
 htp_table_t *htp_table_create(size_t size) {
     if (size == 0) return NULL;
 

--- a/htp/htp_table.h
+++ b/htp/htp_table.h
@@ -94,15 +94,6 @@ htp_status_t htp_table_addk(htp_table_t *table, const bstr *key, const void *ele
 void htp_table_clear(htp_table_t *table);
 
 /**
- * Remove all elements from the table without freeing any of the keys, even
- * if the table is using an allocation strategy where keys belong to it. This
- * function is useful if all the keys have been adopted by some other structure.
- *
- * @param[in] table
- */
-void htp_table_clear_ex(htp_table_t *table);
-
-/**
  * Create a new table structure. The table will grow automatically as needed,
  * but you are required to provide a starting size.
  *

--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -209,11 +209,6 @@ void htp_tx_destroy_incomplete(htp_tx_t *tx) {
     free(tx);
 }
 
-int htp_tx_get_is_config_shared(const htp_tx_t *tx) {
-    if (tx == NULL) return -1;
-    return tx->is_config_shared;
-}
-
 void *htp_tx_get_user_data(const htp_tx_t *tx) {
     if (tx == NULL) return NULL;
     return tx->user_data;

--- a/htp/htp_transaction.h
+++ b/htp/htp_transaction.h
@@ -109,16 +109,6 @@ htp_tx_t *htp_tx_create(htp_connp_t *connp);
 htp_status_t htp_tx_destroy(htp_tx_t *tx);
 
 /**
- * Determines if the transaction used a shared configuration structure. See the
- * documentation for htp_tx_set_config() for more information why you might want
- * to know that.
- *
- * @param[in] tx Transaction pointer. Must not be NULL.
- * @return HTP_CFG_SHARED or HTP_CFG_PRIVATE.
- */
-int htp_tx_get_is_config_shared(const htp_tx_t *tx);
-
-/**
  * Returns the user data associated with this transaction.
  *
  * @param[in] tx Transaction pointer. Must not be NULL.

--- a/htp/htp_utf8_decoder.c
+++ b/htp/htp_utf8_decoder.c
@@ -97,26 +97,6 @@ static const uint8_t utf8d_allow_overlong[] = {
 };
 
 /**
- * Process one byte of UTF-8 data and return a code point if one is available.
- *
- * @param[in] state
- * @param[in] codep
- * @param[in] byte
- * @return HTP_UTF8_ACCEPT for a valid character, HTP_UTF8_REJECT for an invalid character,
- *         or something else if the character has not yet been formed
- */
-uint32_t htp_utf8_decode(uint32_t* state, uint32_t* codep, uint32_t byte) {
-  uint32_t type = utf8d[byte];
-
-  *codep = (*state != HTP_UTF8_ACCEPT) ?
-    (byte & 0x3fu) | (*codep << 6) :
-    (0xff >> type) & (byte);
-
-  *state = utf8d[256 + *state*16 + type];
-  return *state;
-}
-
-/**
  * Process one byte of UTF-8 data and return a code point if one is available. Allows
  * overlong characters in input.
  *

--- a/htp/htp_utf8_decoder.h
+++ b/htp/htp_utf8_decoder.h
@@ -76,7 +76,6 @@ extern "C" {
 #define HTP_UTF8_ACCEPT 0
 #define HTP_UTF8_REJECT 1
 
-uint32_t htp_utf8_decode(uint32_t* state, uint32_t* codep, uint32_t byte);
 uint32_t htp_utf8_decode_allow_overlong(uint32_t* state, uint32_t* codep, uint32_t byte);
 
 #ifdef __cplusplus

--- a/htp/htp_util.c
+++ b/htp/htp_util.c
@@ -90,18 +90,6 @@ int htp_is_separator(int c) {
 }
 
 /**
- * Is character a text character?
- *
- * @param[in] c
- * @return 0 or 1
- */
-int htp_is_text(int c) {
-    if (c == '\t') return 1;
-    if (c < 32) return 0;
-    return 1;
-}
-
-/**
  * Is character a token character?
  *
  * @param[in] c
@@ -2247,118 +2235,6 @@ char *htp_tx_response_progress_as_string(htp_tx_t *tx) {
     }
 
     return "INVALID";
-}
-
-bstr *htp_unparse_uri_noencode(htp_uri_t *uri) {
-    if (uri == NULL) return NULL;    
-
-    // On the first pass determine the length of the final string
-    size_t len = 0;
-
-    if (uri->scheme != NULL) {
-        len += bstr_len(uri->scheme);
-        len += 3; // "://"
-    }
-
-    if ((uri->username != NULL) || (uri->password != NULL)) {
-        if (uri->username != NULL) {
-            len += bstr_len(uri->username);
-        }
-
-        len += 1; // ":"
-
-        if (uri->password != NULL) {
-            len += bstr_len(uri->password);
-        }
-
-        len += 1; // "@"
-    }
-
-    if (uri->hostname != NULL) {
-        len += bstr_len(uri->hostname);
-    }
-
-    if (uri->port != NULL) {
-        len += 1; // ":"
-        len += bstr_len(uri->port);
-    }
-
-    if (uri->path != NULL) {
-        len += bstr_len(uri->path);
-    }
-
-    if (uri->query != NULL) {
-        len += 1; // "?"
-        len += bstr_len(uri->query);
-    }
-
-    if (uri->fragment != NULL) {
-        len += 1; // "#"
-        len += bstr_len(uri->fragment);
-    }
-
-    // On the second pass construct the string
-    bstr *r = bstr_alloc(len);
-    if (r == NULL) return NULL;    
-
-    if (uri->scheme != NULL) {
-        bstr_add_noex(r, uri->scheme);
-        bstr_add_c_noex(r, "://");
-    }
-
-    if ((uri->username != NULL) || (uri->password != NULL)) {
-        if (uri->username != NULL) {
-            bstr_add_noex(r, uri->username);
-        }
-
-        bstr_add_c_noex(r, ":");
-
-        if (uri->password != NULL) {
-            bstr_add_noex(r, uri->password);
-        }
-
-        bstr_add_c_noex(r, "@");
-    }
-
-    if (uri->hostname != NULL) {
-        bstr_add_noex(r, uri->hostname);
-    }
-
-    if (uri->port != NULL) {
-        bstr_add_c_noex(r, ":");
-        bstr_add_noex(r, uri->port);
-    }
-
-    if (uri->path != NULL) {
-        bstr_add_noex(r, uri->path);
-    }
-
-    if (uri->query != NULL) {
-        bstr_add_c_noex(r, "?");
-        bstr_add_noex(r, uri->query);
-
-        /*
-        bstr *query = bstr_dup(uri->query);
-        if (query == NULL) {
-            bstr_free(r);
-            return NULL;
-        }
-
-        htp_uriencoding_normalize_inplace(query);
-
-        bstr_add_c_noex(r, "?");
-        bstr_add_noex(r, query);
-
-        bstr_free(query);
-        */
-    }
-
-    if (uri->fragment != NULL) {
-        bstr_add_c_noex(r, "#");
-        bstr_add_noex(r, uri->fragment);
-    }
-
-    return r;
 }
 
 /**


### PR DESCRIPTION
These were found using coverage by oss-fuzz
https://storage.googleapis.com/oss-fuzz-coverage/libhtp/reports/20190526/linux/src/libhtp/htp/report.html

Next step may be to add fuzz targets to increase coverage (like using `HTP_SERVER_IIS_5_1`or such)