### PR TITLE
Skips leading zeroes while looking for pattern

### DIFF
--- a/htp/bstr.c
+++ b/htp/bstr.c
@@ -546,6 +546,10 @@ int bstr_util_mem_index_of_mem_nocasenorzero(const void *_data1, size_t len1, co
 
     for (i = 0; i < len1; i++) {
         size_t k = i;
+        if (data1[i] == 0) {
+            // skip leading zeroes to avoid quadratic complexity
+            continue;
+        }
 
         for (j = 0; ((j < len2) && (k < len1)); j++, k++) {
             if (data1[k] == 0) {


### PR DESCRIPTION
This avoids quadratic complexity which could lead to DOS (having a buffer starting with a bunch of zeroes)

Found by oss-fuzz https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15727

Added by commit https://github.com/OISF/libhtp/commit/f4dfe268a724d382fc52ea10e49fe5a259195ada in function `bstr_util_mem_index_of_mem_nocasenorzero`