### PR TITLE
coverity: makes sure PRId64 is defined

### DIFF
--- a/htp/htp_private.h
+++ b/htp/htp_private.h
@@ -59,6 +59,7 @@ extern "C" {
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <stdint.h>
 
 #include "htp_config_auto_gen.h"
 #include "htp.h"


### PR DESCRIPTION
Fixes new bugs found by coverity

This makes sure stdint.h is included so that `PRId64` and such are defined

Otherwise, it is interpreted as an empty string, and the format string does not use its arguments