### PR TITLE
lzma: make decompression optional at runtime

### DIFF
--- a/htp/htp_decompressors.c
+++ b/htp/htp_decompressors.c
@@ -439,7 +439,12 @@ htp_decompressor_t *htp_gzip_decompressor_create(htp_connp_t *connp, enum htp_co
 
     switch (format) {
         case HTP_COMPRESSION_LZMA:
-            LzmaDec_Construct(&drec->state);
+            if (d->tx->cfg->lzma_memlimit > 0) {
+                LzmaDec_Construct(&drec->state);
+            } else {
+                htp_log(d->tx->connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "LZMA decompression disabled");
+                drec->passthrough = 1;
+            }
             rc = Z_OK;
             break;
         case HTP_COMPRESSION_DEFLATE:


### PR DESCRIPTION
Logs a warning if LZMA is disabled and we encounter it

Disabling it can be done by calling `htp_config_set_lzma_memlimit` with a 0 limit