### PR TITLE
Adds a compression bomb limit

### DIFF
--- a/htp/htp_config.c
+++ b/htp/htp_config.c
@@ -159,6 +159,7 @@ htp_cfg_t *htp_config_create(void) {
     cfg->extract_request_files_limit = -1; // Use the parser default.
     cfg->response_decompression_layer_limit = 2; // 2 layers seem fairly common
     cfg->lzma_memlimit = HTP_LZMA_MEMLIMIT;
+    cfg->compression_bomb_limit = HTP_COMPRESSION_BOMB_LIMIT;
 
     // Default settings for URL-encoded data.
 
@@ -511,6 +512,15 @@ void htp_config_set_field_limits(htp_cfg_t *cfg, size_t soft_limit, size_t hard_
 void htp_config_set_lzma_memlimit(htp_cfg_t *cfg, size_t memlimit) {
     if (cfg == NULL) return;
     cfg->lzma_memlimit = memlimit;
+}
+
+void htp_config_set_compression_bomb_limit(htp_cfg_t *cfg, size_t bomblimit) {
+    if (cfg == NULL) return;
+    if (bomblimit > INT32_MAX) {
+        cfg->compression_bomb_limit = INT32_MAX;
+    } else {
+        cfg->compression_bomb_limit = bomblimit;
+    }
 }
 
 void htp_config_set_log_level(htp_cfg_t *cfg, enum htp_log_level_t log_level) {

--- a/htp/htp_config.h
+++ b/htp/htp_config.h
@@ -435,6 +435,14 @@ void htp_config_set_field_limits(htp_cfg_t *cfg, size_t soft_limit, size_t hard_
 void htp_config_set_lzma_memlimit(htp_cfg_t *cfg, size_t memlimit);
 
 /**
+ * Configures the maximum compression bomb size LibHTP will decompress.
+ *
+ * @param[in] cfg
+ * @param[in] bomblimit
+ */
+void htp_config_set_compression_bomb_limit(htp_cfg_t *cfg, size_t bomblimit);
+
+/**
  * Configures the desired log level.
  * 
  * @param[in] cfg

--- a/htp/htp_config_private.h
+++ b/htp/htp_config_private.h
@@ -345,6 +345,9 @@ struct htp_cfg_t {
 
     /** max memory use by a the lzma decompressor. */
     size_t lzma_memlimit;
+
+    /** max output size for a compression bomb. */
+    int32_t compression_bomb_limit;
 };
 
 #ifdef	__cplusplus

--- a/htp/htp_private.h
+++ b/htp/htp_private.h
@@ -79,6 +79,9 @@ extern "C" {
 
 // 1048576 is 1 Mbyte
 #define HTP_LZMA_MEMLIMIT                   1048576
+//deflate max ratio is about 1000
+#define HTP_COMPRESSION_BOMB_RATIO          2048
+#define HTP_COMPRESSION_BOMB_LIMIT          1048576
 
 #define HTP_FIELD_LIMIT_HARD               18000
 #define HTP_FIELD_LIMIT_SOFT               9000

--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -789,6 +789,13 @@ static htp_status_t htp_tx_res_process_body_data_decompressor_callback(htp_tx_da
     // Invoke all callbacks.
     htp_status_t rc = htp_res_run_hook_body_data(d->tx->connp, d);
     if (rc != HTP_OK) return HTP_ERROR;
+    if (d->tx->response_entity_len > d->tx->connp->cfg->compression_bomb_limit &&
+        d->tx->response_entity_len > HTP_COMPRESSION_BOMB_RATIO * d->tx->response_message_len) {
+        htp_log(d->tx->connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                "Compression bomb: decompressed %d bytes out of %d",
+                d->tx->response_entity_len, d->tx->response_message_len);
+        return HTP_ERROR;
+    }
 
     return HTP_OK;
 }


### PR DESCRIPTION
Triggers when a fixed compression ratio is crossed
And when a configurable output size is reached
Stops decompression and logs an error in this case

Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=17485

Suricata PR https://github.com/OISF/suricata/pull/4222

Replaces #254 with code review :
- lower bomb compression ratio to 2048
- use `int32_t` for `compression_bomb_limit` instead of `int64_t` and check for overflow in `htp_config_set_compression_bomb_limit`