### PR TITLE
fuzz: fuzzit integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ compiler:
   - gcc
   - clang
 # Change this to your needs
-script: sh autogen.sh && ./configure && make && make check && make distcheck
+script:
+  - sh autogen.sh && ./configure --enable-fuzztargets && make && make check && make distcheck
+  - if [ -n "$QA_FUZZIT" ]; then test/fuzzit.sh; fi
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y build-essential autoconf automake libtool zlib1g zlib1g-dev make 
@@ -11,14 +13,14 @@ before_install:
 matrix:
     include:
         - name: fuzza
-          env: CXX="clang++" ASAN_OPTIONS=detect_leaks=0 CXXFLAGS="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address" CFLAGS="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address" LDFLAGS="-fsanitize=address"
+          env: CXX="clang++" ASAN_OPTIONS=detect_leaks=0 CXXFLAGS="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize=fuzzer-no-link" CFLAGS="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=address -fsanitize=fuzzer-no-link" LDFLAGS="-fsanitize=address" QA_FUZZIT=asan
           compiler: clang
           os: linux
         - name: fuzzm
-          env: CXX="clang++" CXXFLAGS="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=memory" CFLAGS="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=memory" LDFLAGS="-fsanitize=memory"
+          env: CXX="clang++" CXXFLAGS="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=memory -fsanitize=fuzzer-no-link" CFLAGS="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=memory -fsanitize=fuzzer-no-link" LDFLAGS="-fsanitize=memory" QA_FUZZIT=msan
           compiler: clang
           os: linux
         - name: fuzzu
-          env: CXX="clang++" CXXFLAGS="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=undefined" CFLAGS="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=undefined -fno-sanitize-recover=undefined,integer" LDFLAGS="-fsanitize=undefined"
+          env: CXX="clang++" CXXFLAGS="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=undefined -fsanitize=fuzzer-no-link" CFLAGS="-DFUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION -fsanitize=undefined -fno-sanitize-recover=undefined,integer -fsanitize=fuzzer-no-link" LDFLAGS="-fsanitize=undefined" QA_FUZZIT=ubsan
           compiler: clang
           os: linux

--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,36 @@ if test "$enable_gcov" = "yes"; then
     echo "gcov support enabled"
 fi
 
+AC_ARG_ENABLE(fuzztargets,
+    AS_HELP_STRING([--enable-fuzztargets], [Enable fuzz targets]),[enable_fuzztargets=$enableval],[enable_fuzztargets=no])
+AM_CONDITIONAL([BUILD_FUZZTARGETS], [test "x$enable_fuzztargets" = "xyes"])
+AS_IF([test "x$enable_fuzztargets" = "xyes"], [
+    AS_IF([test "x$LIB_FUZZING_ENGINE" = "x"], [
+        LIB_FUZZING_ENGINE=-fsanitize=fuzzer
+        AC_SUBST(LIB_FUZZING_ENGINE)
+    ])
+    AC_LANG_PUSH(C++)
+    tmp_saved_flags=$CXXFLAGS
+    CXXFLAGS="$CXXFLAGS $LIB_FUZZING_ENGINE"
+    AC_MSG_CHECKING([whether $CXX accepts $LIB_FUZZING_ENGINE])
+    AC_LINK_IFELSE([AC_LANG_SOURCE([[
+#include <sys/types.h>
+extern "C" int LLVMFuzzerTestOneInput(const unsigned char *Data, size_t Size);
+extern "C" int LLVMFuzzerTestOneInput(const unsigned char *Data, size_t Size) {
+(void)Data;
+(void)Size;
+return 0;
+}
+    ]])],
+    [ AC_MSG_RESULT(yes)
+      has_sanitizefuzzer=yes],
+    [ AC_MSG_RESULT(no) ]
+    )
+    CXXFLAGS=$tmp_saved_flags
+    AC_LANG_POP()
+])
+
+AM_CONDITIONAL([HAS_FUZZLDFLAGS], [test "x$has_sanitizefuzzer" = "xyes"])
 CFLAGS="${CFLAGS} -O${OLEVEL}"
 CPPFLAGS="${CPPFLAGS} -O${OLEVEL}"
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -9,14 +9,23 @@ AM_CPPFLAGS = -I$(top_srcdir) -I$(top_builddir)/htp -Wno-write-strings -DGTEST_U
 
 AUTOMAKE_OPTIONS = subdir-objects
 EXTRA_DIST = files
-check_PROGRAMS = test_all test_fuzz
+check_PROGRAMS = test_all
+if BUILD_FUZZTARGETS
+    check_PROGRAMS += fuzz_htp
+endif
 check_LIBRARIES = libgtest.a
 
 test_all_SOURCES = test_bstr.cpp test_gunzip.cpp test_hybrid.cpp test_main.cpp test_multipart.cpp test.c test.h test_utils.cpp test_bench.cpp
 test_all_LDADD = libgtest.a -lpthread $(LDADD)
 
-test_fuzz_SOURCES = fuzz/onefile.c fuzz/fuzz_htp.c fuzz/fuzz_htp.h test.c
-test_fuzz_LDADD = $(LDADD)
+fuzz_htp_SOURCES = fuzz/fuzz_htp.c fuzz/fuzz_htp.h test.c
+# use static version of libhtp
+fuzz_htp_LDADD = $(top_builddir)/htp/.libs/libhtp.a -lz @LIBICONV@
+if HAS_FUZZLDFLAGS
+    fuzz_htp_LDFLAGS = $(LIB_FUZZING_ENGINE)
+else
+    fuzz_htp_SOURCES += fuzz/onefile.c
+endif
 
 libgtest_a_SOURCES = gtest/gtest-all.cc gtest/gtest_main.cc gtest/gtest.h
 

--- a/test/fuzzit.sh
+++ b/test/fuzzit.sh
@@ -1,0 +1,23 @@
+#TODO use travis Encrypting environment variables
+export FUZZIT_API_KEY=a5bd225de146e4528ee53fc64e713946cb5462fefc31d7c99633ff93899ed0f8b3bdde0beba8a94afb04619064dd8a65
+
+[ -s ./test/fuzz_htp ] || exit 0
+
+if [ "$TRAVIS_EVENT_TYPE" = 'cron' ]; then
+    FUZZING_TYPE=fuzzing
+else
+    FUZZING_TYPE=local-regression
+fi
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    FUZZIT_BRANCH="${TRAVIS_BRANCH}"
+else
+    FUZZIT_BRANCH="PR-${TRAVIS_PULL_REQUEST}"
+fi
+
+FUZZIT_ARGS="--type ${FUZZING_TYPE} --branch ${FUZZIT_BRANCH} --revision ${TRAVIS_COMMIT}"
+
+wget -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.60/fuzzit_Linux_x86_64
+chmod +x fuzzit
+set -x
+./fuzzit create job ${FUZZIT_ARGS} fuzz-htp-${QA_FUZZIT} ./test/fuzz_htp
+set +x


### PR DESCRIPTION
This PR integrates libhtp with fuzzit, a continuous fuzzing platform (such as oss-fuzz)

Travis builds sends built fuzzers to Fuzzit platform for running.

In order to do that, there were some modifications needed to the auto tool compilation scheme, in order to build the fuzzers

There will be one thing to do for merging that I cannot do :
Use travis secret management https://docs.travis-ci.com/user/encryption-keys/ to secure the API key

cc @yevgenypats

Modifies #259 using local-regression instead of regression for Fuzzit job types in order to have inline feedback into Travis