### PR TITLE
Post data decompression v2

### DIFF
--- a/htp/htp_connection_parser_private.h
+++ b/htp/htp_connection_parser_private.h
@@ -253,6 +253,9 @@ struct htp_connp_t {
     /** Response decompressor used to decompress response body data. */
     htp_decompressor_t *out_decompressor;
 
+    /** Request decompressor used to decompress request body POST data. */
+    htp_decompressor_t *req_decompressor;
+
     /** On a PUT request, this field contains additional file data. */
     htp_file_t *put_file;
 };


### PR DESCRIPTION
Fixes https://redmine.openinfosecfoundation.org/issues/2510

- Moves some code up in htp_transaction.c
- Creates `htp_tx_req_process_body_data_decompressor_callback` similar to `htp_tx_res_process_body_data_decompressor_callback` but using fields such as `request_entity_len` instead of `response_entity_len`
- Creates common function `htp_tx_init_decompressor`
- Modifies `htp_tx_process_request_headers` to fill `tx->request_content_encoding` and init decompressor
- Modifies `htp_tx_req_process_body_data_ex` to decompress data if needed

Remarks :
- Some configuration fields are used for both request and response and not renamed : `response_decompression_layer_limit` and `response_decompression_enabled`
- I made a different use of `response_decompression_enabled` so as not to add a field such as `request_content_encoding_processing` to `htp_tx_t` structure

Test in https://github.com/OISF/suricata-verify/pull/133

Changes #261 :
- moves `HTP_COMPRESSION_NONE` case first in the switch
- decomposes in different commits
- adds a `req_decompressor` field so that request and response can be decompressed at the same time