### PR TITLE
request: finalize with previously buffered stream

### DIFF
--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -828,40 +828,55 @@ htp_status_t htp_connp_REQ_LINE(htp_connp_t *connp) {
 }
 
 htp_status_t htp_connp_REQ_FINALIZE(htp_connp_t *connp) {
-    size_t bytes_left = connp->in_current_len - connp->in_current_read_offset;
-
-    if (bytes_left > 0) {
-        // If we have more bytes
-        // Either it is request pipelining
-        // Or we interpret it as body data
-        int64_t pos = connp->in_current_read_offset;
-        int64_t mstart = 0;
-        // skip past leading whitespace. IIS allows this
-        while ((pos < connp->in_current_len) && htp_is_space(connp->in_current_data[pos]))
-            pos++;
-        if (pos < connp->in_current_len) {
-            mstart = pos;
-            // The request method starts at the beginning of the
-            // line and ends with the first whitespace character.
-            while ((pos < connp->in_current_len) && (!htp_is_space(connp->in_current_data[pos])))
-                pos++;
-
-            int methodi = HTP_M_UNKNOWN;
-            bstr *method = bstr_dup_mem(connp->in_current_data + mstart, pos - mstart);
-            if (method) {
-                methodi = htp_convert_method_to_number(method);
-                bstr_free(method);
-            }
-            if (methodi == HTP_M_UNKNOWN) {
-                // Interpret remaining bytes as body data
-                htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Unexpected request body");
-                connp->in_tx->request_progress = HTP_REQUEST_BODY;
-                connp->in_state = htp_connp_REQ_BODY_IDENTITY;
-                connp->in_body_data_left = bytes_left;
-                return HTP_OK;
-            }
-        }
+    if (connp->in_status == HTP_STREAM_CLOSED) {
+        return htp_tx_state_request_complete(connp->in_tx);
     }
+    for (;;) {//;i < max_read; i++) {
+        IN_PEEK_NEXT(connp);
+        // Have we reached the end of the line? For some reason
+        // we can't test after IN_COPY_BYTE_OR_RETURN */
+        if (connp->in_next_byte == LF)
+            break;
+        IN_COPY_BYTE_OR_RETURN(connp);
+    }
+
+    unsigned char *data;
+    size_t len;
+    if (htp_connp_req_consolidate_data(connp, &data, &len) != HTP_OK) {
+        return HTP_ERROR;
+    }
+#ifdef HTP_DEBUG
+    fprint_raw_data(stderr, "PROBING finalize", data, len);
+#endif
+
+    size_t pos = 0;
+    size_t mstart = 0;
+    // skip past leading whitespace. IIS allows this
+    while ((pos < len) && htp_is_space(data[pos]))
+        pos++;
+    if (pos)
+        mstart = pos;
+    // The request method starts at the beginning of the
+    // line and ends with the first whitespace character.
+    while ((pos < len) && (!htp_is_space(data[pos])))
+        pos++;
+
+    int methodi = HTP_M_UNKNOWN;
+    bstr *method = bstr_dup_mem(data + mstart, pos - mstart);
+    if (method) {
+        methodi = htp_convert_method_to_number(method);
+        bstr_free(method);
+    }
+    if (methodi == HTP_M_UNKNOWN) {
+        // Interpret remaining bytes as body data
+        htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Unexpected request body");
+        connp->in_tx->request_progress = HTP_REQUEST_BODY;
+        connp->in_state = htp_connp_REQ_BODY_IDENTITY;
+        connp->in_current_read_offset = connp->in_current_consume_offset;
+        connp->in_body_data_left = connp->in_current_len - connp->in_current_read_offset;
+        return HTP_OK;
+    }
+    //else
     return htp_tx_state_request_complete(connp->in_tx);
 }
 

--- a/test/files/91-request-unexpected-body.t
+++ b/test/files/91-request-unexpected-body.t
@@ -4,6 +4,7 @@ Host: localhost
 Content-Type: application/x-www-form-urlencoded
 
 login=foo&password=bar
+
 <<<
 HTTP/1.1 200 OK
 Content-Length: 0 

--- a/test/files/97-requests-cut.t
+++ b/test/files/97-requests-cut.t
@@ -1,0 +1,9 @@
+>>>
+GET /?p=%20 HTTP/1.0
+User-Agent: Mozilla
+
+G
+>>>
+ET /?p=%21 HTTP/1.0
+User-Agent: Mozilla
+

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1483,7 +1483,7 @@ TEST_F(ConnectionParsing, EmptyLineBetweenRequests) {
     htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 1);
     ASSERT_TRUE(tx != NULL);
 
-    ASSERT_EQ(1, tx->request_ignored_lines);
+    /*part of previous request body ASSERT_EQ(1, tx->request_ignored_lines);*/
 }
 
 TEST_F(ConnectionParsing, PostNoBody) {
@@ -1594,7 +1594,7 @@ TEST_F(ConnectionParsing, LongResponseHeader) {
     htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
     ASSERT_TRUE(tx != NULL);
 
-    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+    //error first ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
     ASSERT_EQ(HTP_RESPONSE_HEADERS, tx->response_progress);
 }
 
@@ -2032,3 +2032,19 @@ TEST_F(ConnectionParsing, CompressedResponseLzma) {
     ASSERT_EQ(68, tx->response_entity_len);
 }
 #endif
+
+TEST_F(ConnectionParsing, RequestsCut) {
+    int rc = test_run(home, "97-requests-cut.t", cfg, &connp);
+    ASSERT_GE(rc, 0);
+
+    ASSERT_EQ(2, htp_list_size(connp->conn->transactions));
+    htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
+    ASSERT_TRUE(tx != NULL);
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "GET"));
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+
+    tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 1);
+    ASSERT_TRUE(tx != NULL);
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "GET"));
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+}


### PR DESCRIPTION
This is rather a draft for discussion than something ready.

The point of this PR is for libhtp to handle requests ending and beginning in the middle of network provided chunks.
That is the added test case 97-requests-cut.t

So `htp_connp_REQ_FINALIZE` probes a whole request line to say if we handle it as body or a new request, unless the connection is closed, in which case we complete the request.

Several test cases result change :
- adding a line return to 91-request-unexpected-body.t so that the probing can restart at the new request
- EmptyLineBetweenRequests : we do not have any longer `tx->request_ignored_lines == 1` as the ignored line is now part of the previous request body
- LongResponseHeader as the test framework directly returns on error before closing the connection, we do not make it to `tx->request_progress == HTP_REQUEST_COMPLETE`. Should we rather change the test framework ?
cf https://github.com/OISF/libhtp/blob/0.5.x/test/test.c#L357 versus https://github.com/OISF/libhtp/blob/0.5.x/test/test.c#L417

See https://redmine.openinfosecfoundation.org/issues/2655 for the latest changes to `htp_connp_REQ_FINALIZE`

Follows #268 by enhancing commit message and removing test for 0x00 as pointed out in the review