### PR TITLE
time: Adds time limit for pure decompression

### DIFF
--- a/htp/htp_config.c
+++ b/htp/htp_config.c
@@ -160,6 +160,7 @@ htp_cfg_t *htp_config_create(void) {
     cfg->response_decompression_layer_limit = 2; // 2 layers seem fairly common
     cfg->lzma_memlimit = HTP_LZMA_MEMLIMIT;
     cfg->compression_bomb_limit = HTP_COMPRESSION_BOMB_LIMIT;
+    cfg->compression_time_limit = HTP_COMPRESSION_TIME_LIMIT;
 
     // Default settings for URL-encoded data.
 
@@ -521,6 +522,11 @@ void htp_config_set_compression_bomb_limit(htp_cfg_t *cfg, size_t bomblimit) {
     } else {
         cfg->compression_bomb_limit = bomblimit;
     }
+}
+
+void htp_config_set_compression_time_limit(htp_cfg_t *cfg, size_t timelimit) {
+    if (cfg == NULL) return;
+    cfg->compression_time_limit = timelimit;
 }
 
 void htp_config_set_log_level(htp_cfg_t *cfg, enum htp_log_level_t log_level) {

--- a/htp/htp_config.h
+++ b/htp/htp_config.h
@@ -443,6 +443,14 @@ void htp_config_set_lzma_memlimit(htp_cfg_t *cfg, size_t memlimit);
 void htp_config_set_compression_bomb_limit(htp_cfg_t *cfg, size_t bomblimit);
 
 /**
+ * Configures the maximum compression bomb time LibHTP will decompress.
+ *
+ * @param[in] cfg
+ * @param[in] timelimit
+ */
+void htp_config_set_compression_time_limit(htp_cfg_t *cfg, size_t timelimit);
+
+/**
  * Configures the desired log level.
  * 
  * @param[in] cfg

--- a/htp/htp_config_private.h
+++ b/htp/htp_config_private.h
@@ -348,6 +348,9 @@ struct htp_cfg_t {
 
     /** max output size for a compression bomb. */
     int32_t compression_bomb_limit;
+
+    /** max time for a decompression bomb. */
+    uint64_t compression_time_limit;
 };
 
 #ifdef	__cplusplus

--- a/htp/htp_decompressors.h
+++ b/htp/htp_decompressors.h
@@ -59,6 +59,7 @@ struct htp_decompressor_t {
     htp_status_t (*callback)(htp_tx_data_t *);
     void (*destroy)(htp_decompressor_t *);
     struct htp_decompressor_t *next;
+    uint64_t time_spent;
 };
 
 struct htp_decompressor_gzip_t {

--- a/htp/htp_private.h
+++ b/htp/htp_private.h
@@ -83,6 +83,8 @@ extern "C" {
 //deflate max ratio is about 1000
 #define HTP_COMPRESSION_BOMB_RATIO          2048
 #define HTP_COMPRESSION_BOMB_LIMIT          1048576
+// 1 second
+#define HTP_COMPRESSION_TIME_LIMIT          1000000
 
 #define HTP_FIELD_LIMIT_HARD               18000
 #define HTP_FIELD_LIMIT_SOFT               9000


### PR DESCRIPTION
To avoid DOS by small repeated zip bombs

This PR is a first draft.
This already fixes attack found by oss-fuzz https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18323
Here are the open questions :
- what should be the scope of the time measurement ? I chose the call of `tx->connp->out_decompressor->decompress`
- what is a good default value ? A second ?
- do we have to deal with the race condition of computer time change during our run ?
- Is `htp_decompressor_t` the right structure to add the field `time_spent` ?