### PR TITLE
finalize: handles requests and responses across packets

### DIFF
--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -828,39 +828,66 @@ htp_status_t htp_connp_REQ_LINE(htp_connp_t *connp) {
 }
 
 htp_status_t htp_connp_REQ_FINALIZE(htp_connp_t *connp) {
-    size_t bytes_left = connp->in_current_len - connp->in_current_read_offset;
-
-    if (bytes_left > 0) {
-        // If we have more bytes
-        // Either it is request pipelining
-        // Or we interpret it as body data
-        int64_t pos = connp->in_current_read_offset;
-        int64_t mstart = 0;
-        // skip past leading whitespace. IIS allows this
-        while ((pos < connp->in_current_len) && htp_is_space(connp->in_current_data[pos]))
-            pos++;
-        if (pos < connp->in_current_len) {
-            mstart = pos;
-            // The request method starts at the beginning of the
-            // line and ends with the first whitespace character.
-            while ((pos < connp->in_current_len) && (!htp_is_space(connp->in_current_data[pos])))
-                pos++;
-
-            int methodi = HTP_M_UNKNOWN;
-            bstr *method = bstr_dup_mem(connp->in_current_data + mstart, pos - mstart);
-            if (method) {
-                methodi = htp_convert_method_to_number(method);
-                bstr_free(method);
-            }
-            if (methodi == HTP_M_UNKNOWN) {
-                // Interpret remaining bytes as body data
-                htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Unexpected request body");
-                connp->in_tx->request_progress = HTP_REQUEST_BODY;
-                connp->in_state = htp_connp_REQ_BODY_IDENTITY;
-                connp->in_body_data_left = bytes_left;
-                return HTP_OK;
+    if (connp->in_status != HTP_STREAM_CLOSED) {
+        IN_PEEK_NEXT(connp);
+        if (connp->in_next_byte == -1) {
+            return htp_tx_state_request_complete(connp->in_tx);
+        }
+        if (connp->in_next_byte != LF || connp->in_current_consume_offset >= connp->in_current_read_offset) {
+            for (;;) {//;i < max_read; i++) {
+                IN_COPY_BYTE_OR_RETURN(connp);
+                // Have we reached the end of the line? For some reason
+                // we can't test after IN_COPY_BYTE_OR_RETURN */
+                if (connp->in_next_byte == LF)
+                    break;
             }
         }
+    }
+
+    unsigned char *data;
+    size_t len;
+    if (htp_connp_req_consolidate_data(connp, &data, &len) != HTP_OK) {
+        return HTP_ERROR;
+    }
+#ifdef HTP_DEBUG
+    fprint_raw_data(stderr, "PROBING request finalize", data, len);
+#endif
+    if (len == 0) {
+        //closing
+        return htp_tx_state_request_complete(connp->in_tx);
+    }
+
+    size_t pos = 0;
+    size_t mstart = 0;
+    // skip past leading whitespace. IIS allows this
+    while ((pos < len) && htp_is_space(data[pos]))
+        pos++;
+    if (pos)
+        mstart = pos;
+    // The request method starts at the beginning of the
+    // line and ends with the first whitespace character.
+    while ((pos < len) && (!htp_is_space(data[pos])))
+        pos++;
+
+    int methodi = HTP_M_UNKNOWN;
+    bstr *method = bstr_dup_mem(data + mstart, pos - mstart);
+    if (method) {
+        methodi = htp_convert_method_to_number(method);
+        bstr_free(method);
+    }
+    if (methodi == HTP_M_UNKNOWN) {
+        // Interpret remaining bytes as body data
+        htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Unexpected request body");
+        htp_status_t rc = htp_tx_req_process_body_data_ex(connp->in_tx, data, len);
+        htp_connp_req_clear_buffer(connp);
+        return rc;
+    }
+    //else
+    //unread last end of line so that REQ_LINE works
+    if (connp->in_current_read_offset < (int64_t)len) {
+        connp->in_current_read_offset=0;
+    } else {
+        connp->in_current_read_offset-=len;
     }
     return htp_tx_state_request_complete(connp->in_tx);
 }

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -1070,21 +1070,49 @@ size_t htp_connp_res_data_consumed(htp_connp_t *connp) {
 }
 
 htp_status_t htp_connp_RES_FINALIZE(htp_connp_t *connp) {
-    int bytes_left = connp->out_current_len - connp->out_current_read_offset;
-    unsigned char * data = connp->out_current_data + connp->out_current_read_offset;
+    if (connp->out_status != HTP_STREAM_CLOSED) {
+        OUT_PEEK_NEXT(connp);
+        if (connp->out_next_byte == -1) {
+            return htp_tx_state_response_complete_ex(connp->out_tx, 0);
+        }
+        if (connp->out_next_byte != LF || connp->out_current_consume_offset >= connp->out_current_read_offset) {
+            for (;;) {//;i < max_read; i++) {
+                OUT_COPY_BYTE_OR_RETURN(connp);
+                // Have we reached the end of the line? For some reason
+                // we can't test after IN_COPY_BYTE_OR_RETURN */
+                if (connp->out_next_byte == LF)
+                    break;
+            }
+        }
+    }
+    size_t bytes_left;
+    unsigned char * data;
 
-    if (bytes_left > 0 &&
-        htp_treat_response_line_as_body(data, bytes_left)) {
+    if (htp_connp_res_consolidate_data(connp, &data, &bytes_left) != HTP_OK) {
+        return HTP_ERROR;
+    }
+#ifdef HTP_DEBUG
+    fprint_raw_data(stderr, "PROBING response finalize", data, bytes_left);
+#endif
+    if (bytes_left == 0) {
+        //closing
+        return htp_tx_state_response_complete_ex(connp->out_tx, 0);
+    }
+
+    if (htp_treat_response_line_as_body(data, bytes_left)) {
         // Interpret remaining bytes as body data
         htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Unexpected response body");
-        connp->out_current_read_offset += bytes_left;
-        connp->out_current_consume_offset += bytes_left;
-        connp->out_stream_offset += bytes_left;
-        connp->out_body_data_left -= bytes_left;
         htp_status_t rc = htp_tx_res_process_body_data_ex(connp->out_tx, data, bytes_left);
+        htp_connp_res_clear_buffer(connp);
         return rc;
     }
 
+    //unread last end of line so that RES_LINE works
+    if (connp->out_current_read_offset < (int64_t)bytes_left) {
+        connp->out_current_read_offset=0;
+    } else {
+        connp->out_current_read_offset-=bytes_left;
+    }
     return htp_tx_state_response_complete_ex(connp->out_tx, 0 /* not hybrid mode */);
 }
 

--- a/test/files/91-request-unexpected-body.t
+++ b/test/files/91-request-unexpected-body.t
@@ -4,6 +4,7 @@ Host: localhost
 Content-Type: application/x-www-form-urlencoded
 
 login=foo&password=bar
+
 <<<
 HTTP/1.1 200 OK
 Content-Length: 0 

--- a/test/files/97-requests-cut.t
+++ b/test/files/97-requests-cut.t
@@ -1,0 +1,9 @@
+>>>
+GET /?p=%20 HTTP/1.1
+User-Agent: Mozilla
+
+G
+>>>
+ET /?p=%21 HTTP/1.1
+User-Agent: Mozilla
+

--- a/test/files/98-responses-cut.t
+++ b/test/files/98-responses-cut.t
@@ -1,0 +1,26 @@
+>>>
+GET /?p=%20 HTTP/1.1
+User-Agent: Mozilla
+
+GET /?p=%21 HTTP/1.1
+User-Agent: Mozilla
+
+<<<
+HTTP/1.0 200 OK
+Date: Mon, 31 Aug 2009 20:25:50 GMT
+Server: Apache
+Connection: close
+Content-Type: text/html
+Content-Length: 14
+
+Hello World!
+H
+<<<
+TTP/1.0 200 OK
+Date: Mon, 31 Aug 2009 20:25:50 GMT
+Server: Apache
+Connection: close
+Content-Type: text/html
+Content-Length: 13
+
+Hello People!

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1483,7 +1483,7 @@ TEST_F(ConnectionParsing, EmptyLineBetweenRequests) {
     htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 1);
     ASSERT_TRUE(tx != NULL);
 
-    ASSERT_EQ(1, tx->request_ignored_lines);
+    /*part of previous request body ASSERT_EQ(1, tx->request_ignored_lines);*/
 }
 
 TEST_F(ConnectionParsing, PostNoBody) {
@@ -1594,7 +1594,7 @@ TEST_F(ConnectionParsing, LongResponseHeader) {
     htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
     ASSERT_TRUE(tx != NULL);
 
-    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+    //error first ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
     ASSERT_EQ(HTP_RESPONSE_HEADERS, tx->response_progress);
 }
 
@@ -2032,3 +2032,39 @@ TEST_F(ConnectionParsing, CompressedResponseLzma) {
     ASSERT_EQ(68, tx->response_entity_len);
 }
 #endif
+
+TEST_F(ConnectionParsing, RequestsCut) {
+    int rc = test_run(home, "97-requests-cut.t", cfg, &connp);
+    ASSERT_GE(rc, 0);
+
+    ASSERT_EQ(2, htp_list_size(connp->conn->transactions));
+    htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
+    ASSERT_TRUE(tx != NULL);
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "GET"));
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+
+    tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 1);
+    ASSERT_TRUE(tx != NULL);
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "GET"));
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+}
+
+TEST_F(ConnectionParsing, ResponsesCut) {
+    int rc = test_run(home, "98-responses-cut.t", cfg, &connp);
+    ASSERT_GE(rc, 0);
+
+    ASSERT_EQ(2, htp_list_size(connp->conn->transactions));
+    htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
+    ASSERT_TRUE(tx != NULL);
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "GET"));
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+    ASSERT_EQ(200, tx->response_status_number);
+    ASSERT_EQ(HTP_RESPONSE_COMPLETE, tx->response_progress);
+
+    tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 1);
+    ASSERT_TRUE(tx != NULL);
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "GET"));
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+    ASSERT_EQ(200, tx->response_status_number);
+    ASSERT_EQ(HTP_RESPONSE_COMPLETE, tx->response_progress);
+}


### PR DESCRIPTION
This is now ready

The point of this PR is for libhtp to handle requests/responses ending and beginning in the middle of network provided chunks.
That is the added test case 97-requests-cut.t and 98

So `htp_connp_REQ_FINALIZE` probes a whole request line to say if we handle it as body or a new request, unless the connection is closed, in which case we complete the request.

Several test cases result change :
- adding a line return to 91-request-unexpected-body.t so that the probing can restart at the new request
- EmptyLineBetweenRequests : we do not have any longer `tx->request_ignored_lines == 1` as the ignored line is now part of the previous request body
- LongResponseHeader as the test framework directly returns on error before closing the connection, we do not make it to `tx->request_progress == HTP_REQUEST_COMPLETE`. Should we rather change the test framework ?
cf https://github.com/OISF/libhtp/blob/0.5.x/test/test.c#L357 versus https://github.com/OISF/libhtp/blob/0.5.x/test/test.c#L417

See https://redmine.openinfosecfoundation.org/issues/2655 for the latest changes to `htp_connp_REQ_FINALIZE`

Follows #273 by re-adding htp log 
ie `htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Unexpected request body");` in `htp_connp_REQ_FINALIZE`
