### PR TITLE
cmake: compile scheme available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 2.6)
+
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DDEBUG")
+
+set(INCLUDES ${INCLUDES} ${PROJECT_SOURCE_DIR})
+
+add_subdirectory(htp)
+add_subdirectory(test/fuzz)

--- a/htp/CMakeLists.txt
+++ b/htp/CMakeLists.txt
@@ -1,0 +1,8 @@
+include_directories(${INCLUDES})
+
+add_subdirectory(lzma)
+
+AUX_SOURCE_DIRECTORY(. SOURCES) 
+
+add_library(htp ${SOURCES})
+target_link_libraries(htp htplzma)

--- a/htp/lzma/CMakeLists.txt
+++ b/htp/lzma/CMakeLists.txt
@@ -1,0 +1,5 @@
+include_directories(${INCLUDES})
+
+AUX_SOURCE_DIRECTORY(. SOURCES) 
+
+add_library(htplzma ${SOURCES})

--- a/test/fuzz/CMakeLists.txt
+++ b/test/fuzz/CMakeLists.txt
@@ -1,0 +1,14 @@
+set (INCLUDES ${INCLUDES} ${PROJECT_SOURCE_DIR}/htp ${PROJECT_SOURCE_DIR}/htp/lzma)
+include_directories(${INCLUDES})
+
+add_executable (fuzz_htp fuzz_htp.c onefile.c ../test.c)
+add_executable (fuzz_htpd fuzz_htp.c onedir.c ../test.c)
+
+target_link_libraries (fuzz_htp htp z)
+target_link_libraries (fuzz_htpd htp z)
+
+#add_executable(fuzz_lzma_dec onefile.c fuzz_lzma_dec.c)
+#target_link_libraries(fuzz_lzma_dec lzmac)
+
+#add_executable(fuzz_lzma_round onefile.c fuzz_lzma_round.c)
+#target_link_libraries(fuzz_lzma_round lzmac)


### PR DESCRIPTION
This is a draft PR, not to be merged right now.

This adds a way to compile libhtp with cmake.
This is very basic (lacks checks for packages and such) but it works on a good system.