### PR TITLE
Request finalize v7

### DIFF
--- a/htp/htp_connection_parser.c
+++ b/htp/htp_connection_parser.c
@@ -194,10 +194,6 @@ htp_tx_t *htp_connp_tx_create(htp_connp_t *connp) {
     htp_tx_t *tx = htp_tx_create(connp);
     if (tx == NULL) return NULL;
 
-    connp->in_tx = tx;   
-
-    htp_connp_in_reset(connp);
-
     return tx;
 }
 

--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -927,6 +927,7 @@ htp_status_t htp_connp_REQ_IDLE(htp_connp_t * connp) {
 
     connp->in_tx = htp_connp_tx_create(connp);
     if (connp->in_tx == NULL) return HTP_ERROR;
+    htp_connp_in_reset(connp);
 
     // Change state to TRANSACTION_START
     htp_tx_state_request_start(connp->in_tx);

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -1070,21 +1070,49 @@ size_t htp_connp_res_data_consumed(htp_connp_t *connp) {
 }
 
 htp_status_t htp_connp_RES_FINALIZE(htp_connp_t *connp) {
-    int bytes_left = connp->out_current_len - connp->out_current_read_offset;
-    unsigned char * data = connp->out_current_data + connp->out_current_read_offset;
+    if (connp->out_status != HTP_STREAM_CLOSED) {
+        OUT_PEEK_NEXT(connp);
+        if (connp->out_next_byte == -1) {
+            return htp_tx_state_response_complete_ex(connp->out_tx, 0);
+        }
+        if (connp->out_next_byte != LF || connp->out_current_consume_offset >= connp->out_current_read_offset) {
+            for (;;) {//;i < max_read; i++) {
+                OUT_COPY_BYTE_OR_RETURN(connp);
+                // Have we reached the end of the line? For some reason
+                // we can't test after IN_COPY_BYTE_OR_RETURN */
+                if (connp->out_next_byte == LF)
+                    break;
+            }
+        }
+    }
+    size_t bytes_left;
+    unsigned char * data;
 
-    if (bytes_left > 0 &&
-        htp_treat_response_line_as_body(data, bytes_left)) {
+    if (htp_connp_res_consolidate_data(connp, &data, &bytes_left) != HTP_OK) {
+        return HTP_ERROR;
+    }
+#ifdef HTP_DEBUG
+    fprint_raw_data(stderr, "PROBING response finalize", data, bytes_left);
+#endif
+    if (bytes_left == 0) {
+        //closing
+        return htp_tx_state_response_complete_ex(connp->out_tx, 0);
+    }
+
+    if (htp_treat_response_line_as_body(data, bytes_left)) {
         // Interpret remaining bytes as body data
         htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Unexpected response body");
-        connp->out_current_read_offset += bytes_left;
-        connp->out_current_consume_offset += bytes_left;
-        connp->out_stream_offset += bytes_left;
-        connp->out_body_data_left -= bytes_left;
         htp_status_t rc = htp_tx_res_process_body_data_ex(connp->out_tx, data, bytes_left);
+        htp_connp_res_clear_buffer(connp);
         return rc;
     }
 
+    //unread last end of line so that RES_LINE works
+    if (connp->out_current_read_offset < (int64_t)bytes_left) {
+        connp->out_current_read_offset=0;
+    } else {
+        connp->out_current_read_offset-=bytes_left;
+    }
     return htp_tx_state_response_complete_ex(connp->out_tx, 0 /* not hybrid mode */);
 }
 

--- a/test/files/91-request-unexpected-body.t
+++ b/test/files/91-request-unexpected-body.t
@@ -4,6 +4,7 @@ Host: localhost
 Content-Type: application/x-www-form-urlencoded
 
 login=foo&password=bar
+
 <<<
 HTTP/1.1 200 OK
 Content-Length: 0 

--- a/test/files/97-requests-cut.t
+++ b/test/files/97-requests-cut.t
@@ -1,0 +1,9 @@
+>>>
+GET /?p=%20 HTTP/1.1
+User-Agent: Mozilla
+
+G
+>>>
+ET /?p=%21 HTTP/1.1
+User-Agent: Mozilla
+

--- a/test/files/98-responses-cut.t
+++ b/test/files/98-responses-cut.t
@@ -1,0 +1,26 @@
+>>>
+GET /?p=%20 HTTP/1.1
+User-Agent: Mozilla
+
+GET /?p=%21 HTTP/1.1
+User-Agent: Mozilla
+
+<<<
+HTTP/1.0 200 OK
+Date: Mon, 31 Aug 2009 20:25:50 GMT
+Server: Apache
+Connection: close
+Content-Type: text/html
+Content-Length: 14
+
+Hello World!
+H
+<<<
+TTP/1.0 200 OK
+Date: Mon, 31 Aug 2009 20:25:50 GMT
+Server: Apache
+Connection: close
+Content-Type: text/html
+Content-Length: 13
+
+Hello People!

--- a/test/test_hybrid.cpp
+++ b/test/test_hybrid.cpp
@@ -242,7 +242,7 @@ protected:
  */
 TEST_F(HybridParsing, GetTest) {
     // Create a new LibHTP transaction
-    htp_tx_t *tx = htp_connp_tx_create(connp);
+    htp_tx_t *tx = connp->in_tx = htp_connp_tx_create(connp);
     ASSERT_TRUE(tx != NULL);
 
     // Configure user data and callbacks
@@ -394,7 +394,7 @@ TEST_F(HybridParsing, GetTest) {
  */
 TEST_F(HybridParsing, PostUrlecodedTest) {
     // Create a new LibHTP transaction
-    htp_tx_t *tx = htp_connp_tx_create(connp);
+    htp_tx_t *tx = connp->in_tx = htp_connp_tx_create(connp);
     ASSERT_TRUE(tx != NULL);
 
     // Request begins
@@ -504,7 +504,7 @@ static void HybridParsing_CompressedResponse_Setup(htp_tx_t *tx) {
  */
 TEST_F(HybridParsing, CompressedResponse) {
     // Create a new LibHTP transaction
-    htp_tx_t *tx = htp_connp_tx_create(connp);
+    htp_tx_t *tx = connp->in_tx = htp_connp_tx_create(connp);
     ASSERT_TRUE(tx != NULL);
 
     HybridParsing_CompressedResponse_Setup(tx);
@@ -521,7 +521,7 @@ TEST_F(HybridParsing, CompressedResponseNoDecompression) {
     htp_config_set_response_decompression(cfg, 0);
 
     // Create a new LibHTP transaction
-    htp_tx_t *tx = htp_connp_tx_create(connp);
+    htp_tx_t *tx = connp->in_tx = htp_connp_tx_create(connp);
     ASSERT_TRUE(tx != NULL);
 
     HybridParsing_CompressedResponse_Setup(tx);
@@ -546,7 +546,7 @@ TEST_F(HybridParsing, ForcedDecompression) {
     htp_config_register_response_headers(cfg, HybridParsing_ForcedDecompressionTest_Callback_RESPONSE_HEADERS);
 
     // Create a new LibHTP transaction
-    htp_tx_t *tx = htp_connp_tx_create(connp);
+    htp_tx_t *tx = connp->in_tx = htp_connp_tx_create(connp);
     ASSERT_TRUE(tx != NULL);
 
     HybridParsing_CompressedResponse_Setup(tx);
@@ -571,7 +571,7 @@ TEST_F(HybridParsing, DisableDecompression) {
     htp_config_register_response_headers(cfg, HybridParsing_DisableDecompressionTest_Callback_RESPONSE_HEADERS);
 
     // Create a new LibHTP transaction
-    htp_tx_t *tx = htp_connp_tx_create(connp);
+    htp_tx_t *tx = connp->in_tx = htp_connp_tx_create(connp);
     ASSERT_TRUE(tx != NULL);
 
     HybridParsing_CompressedResponse_Setup(tx);
@@ -582,7 +582,7 @@ TEST_F(HybridParsing, DisableDecompression) {
 
 TEST_F(HybridParsing, ParamCaseSensitivity) {
     // Create a new LibHTP transaction
-    htp_tx_t *tx = htp_connp_tx_create(connp);
+    htp_tx_t *tx = connp->in_tx = htp_connp_tx_create(connp);
     ASSERT_TRUE(tx != NULL);
 
     // Request begins
@@ -628,7 +628,7 @@ TEST_F(HybridParsing, ParamCaseSensitivity) {
  */
 TEST_F(HybridParsing, PostUrlecodedChunked) {
     // Create a new LibHTP transaction.
-    htp_tx_t *tx = htp_connp_tx_create(connp);
+    htp_tx_t *tx = connp->in_tx = htp_connp_tx_create(connp);
     ASSERT_TRUE(tx != NULL);
 
     // Request begins.
@@ -672,7 +672,7 @@ TEST_F(HybridParsing, PostUrlecodedChunked) {
 
 TEST_F(HybridParsing, RequestLineParsing1) {
     // Create a new LibHTP transaction
-    htp_tx_t *tx = htp_connp_tx_create(connp);
+    htp_tx_t *tx = connp->in_tx = htp_connp_tx_create(connp);
     ASSERT_TRUE(tx != NULL);
 
     // Request begins
@@ -702,7 +702,7 @@ TEST_F(HybridParsing, RequestLineParsing1) {
 }
 
 TEST_F(HybridParsing, RequestLineParsing2) {
-    htp_tx_t *tx = htp_connp_tx_create(connp);
+    htp_tx_t *tx = connp->in_tx = htp_connp_tx_create(connp);
     ASSERT_TRUE(tx != NULL);
 
     // Feed data to the parser.
@@ -721,7 +721,7 @@ TEST_F(HybridParsing, RequestLineParsing2) {
 }
 
 TEST_F(HybridParsing, ParsedUriSupplied) {
-    htp_tx_t *tx = htp_connp_tx_create(connp);
+    htp_tx_t *tx = connp->in_tx = htp_connp_tx_create(connp);
     ASSERT_TRUE(tx != NULL);
 
     // Feed data to the parser.
@@ -775,7 +775,7 @@ protected:
 TEST_F(HybridParsing, TestRepeatCallbacks)
 {
     // Create a new LibHTP transaction
-    htp_tx_t *tx = htp_connp_tx_create(connp);
+    htp_tx_t *tx = connp->in_tx = htp_connp_tx_create(connp);
     ASSERT_TRUE(tx != NULL);
 
     // Configure user data and callbacks
@@ -857,7 +857,7 @@ TEST_F(HybridParsing, TestRepeatCallbacks)
 TEST_F(HybridParsing, DeleteTransactionBeforeComplete)
 {
     // Create a new LibHTP transaction
-    htp_tx_t *tx = htp_connp_tx_create(connp);
+    htp_tx_t *tx = connp->in_tx = htp_connp_tx_create(connp);
     ASSERT_TRUE(tx != NULL);
 
     // Request begins

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1483,7 +1483,7 @@ TEST_F(ConnectionParsing, EmptyLineBetweenRequests) {
     htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 1);
     ASSERT_TRUE(tx != NULL);
 
-    ASSERT_EQ(1, tx->request_ignored_lines);
+    /*part of previous request body ASSERT_EQ(1, tx->request_ignored_lines);*/
 }
 
 TEST_F(ConnectionParsing, PostNoBody) {
@@ -1594,7 +1594,7 @@ TEST_F(ConnectionParsing, LongResponseHeader) {
     htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
     ASSERT_TRUE(tx != NULL);
 
-    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+    //error first ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
     ASSERT_EQ(HTP_RESPONSE_HEADERS, tx->response_progress);
 }
 
@@ -2032,3 +2032,39 @@ TEST_F(ConnectionParsing, CompressedResponseLzma) {
     ASSERT_EQ(68, tx->response_entity_len);
 }
 #endif
+
+TEST_F(ConnectionParsing, RequestsCut) {
+    int rc = test_run(home, "97-requests-cut.t", cfg, &connp);
+    ASSERT_GE(rc, 0);
+
+    ASSERT_EQ(2, htp_list_size(connp->conn->transactions));
+    htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
+    ASSERT_TRUE(tx != NULL);
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "GET"));
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+
+    tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 1);
+    ASSERT_TRUE(tx != NULL);
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "GET"));
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+}
+
+TEST_F(ConnectionParsing, ResponsesCut) {
+    int rc = test_run(home, "98-responses-cut.t", cfg, &connp);
+    ASSERT_GE(rc, 0);
+
+    ASSERT_EQ(2, htp_list_size(connp->conn->transactions));
+    htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
+    ASSERT_TRUE(tx != NULL);
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "GET"));
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+    ASSERT_EQ(200, tx->response_status_number);
+    ASSERT_EQ(HTP_RESPONSE_COMPLETE, tx->response_progress);
+
+    tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 1);
+    ASSERT_TRUE(tx != NULL);
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "GET"));
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+    ASSERT_EQ(200, tx->response_status_number);
+    ASSERT_EQ(HTP_RESPONSE_COMPLETE, tx->response_progress);
+}


### PR DESCRIPTION
This is now ready

The point of this PR is for libhtp to handle requests/responses ending and beginning in the middle of network provided chunks.
That is the added test case 97-requests-cut.t and 98

So `htp_connp_REQ_FINALIZE` probes a whole request line to say if we handle it as body or a new request, unless the connection is closed, in which case we complete the request.

Several test cases result change :
- adding a line return to 91-request-unexpected-body.t so that the probing can restart at the new request
- EmptyLineBetweenRequests : we do not have any longer `tx->request_ignored_lines == 1` as the ignored line is now part of the previous request body
- LongResponseHeader as the test framework directly returns on error before closing the connection, we do not make it to `tx->request_progress == HTP_REQUEST_COMPLETE`. Should we rather change the test framework ?
cf https://github.com/OISF/libhtp/blob/0.5.x/test/test.c#L357 versus https://github.com/OISF/libhtp/blob/0.5.x/test/test.c#L417

See https://redmine.openinfosecfoundation.org/issues/2655 for the latest changes to `htp_connp_REQ_FINALIZE`

Follows #278 by adding the changes from #279 which are needed for the tests to pass
