### PR TITLE
time: Adds time limit for pure decompression

### DIFF
--- a/htp/htp_config.c
+++ b/htp/htp_config.c
@@ -160,6 +160,8 @@ htp_cfg_t *htp_config_create(void) {
     cfg->response_decompression_layer_limit = 2; // 2 layers seem fairly common
     cfg->lzma_memlimit = HTP_LZMA_MEMLIMIT;
     cfg->compression_bomb_limit = HTP_COMPRESSION_BOMB_LIMIT;
+    cfg->compression_time_limit.tv_sec = HTP_COMPRESSION_TIME_LIMIT_SEC;
+    cfg->compression_time_limit.tv_usec = HTP_COMPRESSION_TIME_LIMIT_USEC;
 
     // Default settings for URL-encoded data.
 
@@ -521,6 +523,12 @@ void htp_config_set_compression_bomb_limit(htp_cfg_t *cfg, size_t bomblimit) {
     } else {
         cfg->compression_bomb_limit = bomblimit;
     }
+}
+
+void htp_config_set_compression_time_limit(htp_cfg_t *cfg, size_t seclimit, size_t useclimit) {
+    if (cfg == NULL) return;
+    cfg->compression_time_limit.tv_sec = seclimit;
+    cfg->compression_time_limit.tv_usec = useclimit;
 }
 
 void htp_config_set_log_level(htp_cfg_t *cfg, enum htp_log_level_t log_level) {

--- a/htp/htp_config.h
+++ b/htp/htp_config.h
@@ -443,6 +443,15 @@ void htp_config_set_lzma_memlimit(htp_cfg_t *cfg, size_t memlimit);
 void htp_config_set_compression_bomb_limit(htp_cfg_t *cfg, size_t bomblimit);
 
 /**
+ * Configures the maximum compression bomb time LibHTP will decompress.
+ *
+ * @param[in] cfg
+ * @param[in] seclimit
+ * @param[in] useclimit
+ */
+void htp_config_set_compression_time_limit(htp_cfg_t *cfg, size_t seclimit, size_t useclimit);
+
+/**
  * Configures the desired log level.
  * 
  * @param[in] cfg

--- a/htp/htp_config_private.h
+++ b/htp/htp_config_private.h
@@ -348,6 +348,9 @@ struct htp_cfg_t {
 
     /** max output size for a compression bomb. */
     int32_t compression_bomb_limit;
+
+    /** max time for a decompression bomb. */
+    struct timeval compression_time_limit;
 };
 
 #ifdef	__cplusplus

--- a/htp/htp_decompressors.h
+++ b/htp/htp_decompressors.h
@@ -59,6 +59,7 @@ struct htp_decompressor_t {
     htp_status_t (*callback)(htp_tx_data_t *);
     void (*destroy)(htp_decompressor_t *);
     struct htp_decompressor_t *next;
+    struct timeval time_spent;
 };
 
 struct htp_decompressor_gzip_t {

--- a/htp/htp_private.h
+++ b/htp/htp_private.h
@@ -83,6 +83,9 @@ extern "C" {
 //deflate max ratio is about 1000
 #define HTP_COMPRESSION_BOMB_RATIO          2048
 #define HTP_COMPRESSION_BOMB_LIMIT          1048576
+// 1 second
+#define HTP_COMPRESSION_TIME_LIMIT_SEC      1
+#define HTP_COMPRESSION_TIME_LIMIT_USEC     0
 
 #define HTP_FIELD_LIMIT_HARD               18000
 #define HTP_FIELD_LIMIT_SOFT               9000


### PR DESCRIPTION
To avoid DOS by small repeated zip bombs

This PR is a first draft.
It is another version of #274 dealing with https://github.com/OISF/libhtp/pull/274#discussion_r355128131

> Wasn't thinking about time changes, just about a cleaner way to deal with the `struct timeval` then the manual check.

I am not sure this change improves the code, but I may not have fully understood the comment
So I leave #274 open for now