### PR TITLE
finalize: fix unread to unconsume as well

### DIFF
--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -888,8 +888,10 @@ htp_status_t htp_connp_REQ_FINALIZE(htp_connp_t *connp) {
     //unread last end of line so that REQ_LINE works
     if (connp->in_current_read_offset < (int64_t)len) {
         connp->in_current_read_offset=0;
+        connp->in_current_consume_offset=0;
     } else {
         connp->in_current_read_offset-=len;
+        connp->in_current_consume_offset-=len;
     }
     return htp_tx_state_request_complete(connp->in_tx);
 }

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -1110,8 +1110,10 @@ htp_status_t htp_connp_RES_FINALIZE(htp_connp_t *connp) {
     //unread last end of line so that RES_LINE works
     if (connp->out_current_read_offset < (int64_t)bytes_left) {
         connp->out_current_read_offset=0;
+        connp->out_current_consume_offset=0;
     } else {
         connp->out_current_read_offset-=bytes_left;
+        connp->out_current_consume_offset-=bytes_left;
     }
     return htp_tx_state_response_complete_ex(connp->out_tx, 0 /* not hybrid mode */);
 }


### PR DESCRIPTION
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19323

We have to unconsumed as well because of https://github.com/OISF/libhtp/blob/0.5.x/htp/htp_response.c#L234
