### PR TITLE
finalize: fix unread to unconsume as well

### DIFF
--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -891,6 +891,10 @@ htp_status_t htp_connp_REQ_FINALIZE(htp_connp_t *connp) {
     } else {
         connp->in_current_read_offset-=len;
     }
+    if (connp->in_current_read_offset < connp->in_current_consume_offset) {
+        connp->in_current_consume_offset=connp->in_current_read_offset;
+    }
+
     return htp_tx_state_request_complete(connp->in_tx);
 }
 

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -1113,6 +1113,9 @@ htp_status_t htp_connp_RES_FINALIZE(htp_connp_t *connp) {
     } else {
         connp->out_current_read_offset-=bytes_left;
     }
+    if (connp->out_current_read_offset < connp->out_current_consume_offset) {
+        connp->out_current_consume_offset=connp->out_current_read_offset;
+    }
     return htp_tx_state_response_complete_ex(connp->out_tx, 0 /* not hybrid mode */);
 }
 


### PR DESCRIPTION
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19323

We have to unconsumed as well because of https://github.com/OISF/libhtp/blob/0.5.x/htp/htp_response.c#L234

Continues #285 with make check passing