### PR TITLE
Time limit v4

### DIFF
--- a/htp/htp_config.c
+++ b/htp/htp_config.c
@@ -160,6 +160,8 @@ htp_cfg_t *htp_config_create(void) {
     cfg->response_decompression_layer_limit = 2; // 2 layers seem fairly common
     cfg->lzma_memlimit = HTP_LZMA_MEMLIMIT;
     cfg->compression_bomb_limit = HTP_COMPRESSION_BOMB_LIMIT;
+    cfg->compression_time_limit.tv_sec = 0;
+    cfg->compression_time_limit.tv_usec = HTP_COMPRESSION_TIME_LIMIT_USEC;
 
     // Default settings for URL-encoded data.
 
@@ -520,6 +522,17 @@ void htp_config_set_compression_bomb_limit(htp_cfg_t *cfg, size_t bomblimit) {
         cfg->compression_bomb_limit = INT32_MAX;
     } else {
         cfg->compression_bomb_limit = bomblimit;
+    }
+}
+
+void htp_config_set_compression_time_limit(htp_cfg_t *cfg, size_t useclimit) {
+    if (cfg == NULL) return;
+    cfg->compression_time_limit.tv_sec = 0;
+    // max limit is one second
+    if (useclimit >= 1000000) {
+        cfg->compression_time_limit.tv_usec = 999999;
+    } else {
+        cfg->compression_time_limit.tv_usec = useclimit;
     }
 }
 

--- a/htp/htp_config.h
+++ b/htp/htp_config.h
@@ -443,6 +443,14 @@ void htp_config_set_lzma_memlimit(htp_cfg_t *cfg, size_t memlimit);
 void htp_config_set_compression_bomb_limit(htp_cfg_t *cfg, size_t bomblimit);
 
 /**
+ * Configures the maximum compression bomb time LibHTP will decompress.
+ *
+ * @param[in] cfg
+ * @param[in] useclimit
+ */
+void htp_config_set_compression_time_limit(htp_cfg_t *cfg, size_t useclimit);
+
+/**
  * Configures the desired log level.
  * 
  * @param[in] cfg

--- a/htp/htp_config_private.h
+++ b/htp/htp_config_private.h
@@ -348,6 +348,9 @@ struct htp_cfg_t {
 
     /** max output size for a compression bomb. */
     int32_t compression_bomb_limit;
+
+    /** max time for a decompression bomb. */
+    struct timeval compression_time_limit;
 };
 
 #ifdef	__cplusplus

--- a/htp/htp_decompressors.h
+++ b/htp/htp_decompressors.h
@@ -59,6 +59,7 @@ struct htp_decompressor_t {
     htp_status_t (*callback)(htp_tx_data_t *);
     void (*destroy)(htp_decompressor_t *);
     struct htp_decompressor_t *next;
+    struct timeval time_spent;
 };
 
 struct htp_decompressor_gzip_t {

--- a/htp/htp_decompressors.h
+++ b/htp/htp_decompressors.h
@@ -59,7 +59,9 @@ struct htp_decompressor_t {
     htp_status_t (*callback)(htp_tx_data_t *);
     void (*destroy)(htp_decompressor_t *);
     struct htp_decompressor_t *next;
+    struct timeval time_before;
     struct timeval time_spent;
+    uint32_t nb_callbacks;
 };
 
 struct htp_decompressor_gzip_t {

--- a/htp/htp_private.h
+++ b/htp/htp_private.h
@@ -83,6 +83,8 @@ extern "C" {
 //deflate max ratio is about 1000
 #define HTP_COMPRESSION_BOMB_RATIO          2048
 #define HTP_COMPRESSION_BOMB_LIMIT          1048576
+// 0.1 second
+#define HTP_COMPRESSION_TIME_LIMIT_USEC     100000
 
 #define HTP_FIELD_LIMIT_HARD               18000
 #define HTP_FIELD_LIMIT_SOFT               9000

--- a/htp/htp_private.h
+++ b/htp/htp_private.h
@@ -85,6 +85,8 @@ extern "C" {
 #define HTP_COMPRESSION_BOMB_LIMIT          1048576
 // 0.1 second
 #define HTP_COMPRESSION_TIME_LIMIT_USEC     100000
+// test time for compression every 256 callbacks
+#define HTP_COMPRESSION_TIME_FREQ_TEST      256
 
 #define HTP_FIELD_LIMIT_HARD               18000
 #define HTP_FIELD_LIMIT_SOFT               9000

--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -834,8 +834,23 @@ htp_status_t htp_tx_res_process_body_data_ex(htp_tx_t *tx, const void *data, siz
             if (tx->connp->out_decompressor == NULL || tx->connp->out_decompressor->decompress == NULL)
                 return HTP_ERROR;
 
+            struct timeval before, after, duration;
+            gettimeofday(&before, NULL);
             // Send data buffer to the decompressor.
             tx->connp->out_decompressor->decompress(tx->connp->out_decompressor, &d);
+            gettimeofday(&after, NULL);
+            // sanity check for race condition if system time changed
+            if ( timercmp(&after, &before, >) ) {
+                timersub(&after, &before, &duration);
+                timeradd(&tx->connp->out_decompressor->time_spent, &duration, &tx->connp->out_decompressor->time_spent);
+                if ( timercmp(&tx->connp->out_decompressor->time_spent, &tx->connp->cfg->compression_time_limit, >) ) {
+                    htp_log(tx->connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                            "Compression bomb: spent %"PRId64"s and "PRId64" us decompressing",
+                            tx->connp->out_decompressor->time_spent.tv_sec,
+                            tx->connp->out_decompressor->time_spent.tv_usec);
+                    return HTP_ERROR;
+                }
+            }
 
             if (data == NULL) {
                 // Shut down the decompressor, if we used one.


### PR DESCRIPTION
To avoid DOS by small repeated zip bombs or big lzma bomb

Modifies #288 with
- adding checks into `htp_tx_res_process_body_data_decompressor_callback` (called  by `decompress`)
- Checks are not done every iteration of callback but every `HTP_COMPRESSION_TIME_FREQ_TEST` times
- `time_before` is moved to structure to be accessible from `htp_tx_res_process_body_data_decompressor_callback`