### PR TITLE
Fixed empty tx bug in REQ_IDLE

### DIFF
--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -929,6 +929,13 @@ htp_status_t htp_connp_REQ_IDLE(htp_connp_t * connp) {
     // connection.
     IN_TEST_NEXT_BYTE_OR_RETURN(connp);
 
+    // If there is only CRLF left, we just unread last end of line so that REQ_LINE works.
+    // Need more data before starting a new request.
+    if (connp->in_current_read_offset + 2 == connp->in_current_len &&
+        connp->in_current_data[connp->in_current_read_offset] == CR &&
+        connp->in_current_data[connp->in_current_read_offset + 1] == LF)
+        return HTP_DATA;
+
     connp->in_tx = htp_connp_tx_create(connp);
     if (connp->in_tx == NULL) return HTP_ERROR;
 


### PR DESCRIPTION
In `htp_connp_REQ_FINALIZE`, we unread the last end of line so that subsequent calls to `htp_connp_REQ_LINE` work. However, whenever we enter `htp_connp_REQ_IDLE` state, the check `IN_TEST_NEXT_BYTE_OR_RETURN(connp)` always passes even when there is no more data beyond the CRLF creating an empty transaction. `htp_connp_REQ_IDLE` now explicitly checks to make sure that if we only have two bytes of data,  those two bytes are not simply the CRLF before starting a new transaction.