### PR TITLE
time: Adds time limit for pure decompression

### DIFF
--- a/htp/htp_config.c
+++ b/htp/htp_config.c
@@ -160,6 +160,7 @@ htp_cfg_t *htp_config_create(void) {
     cfg->response_decompression_layer_limit = 2; // 2 layers seem fairly common
     cfg->lzma_memlimit = HTP_LZMA_MEMLIMIT;
     cfg->compression_bomb_limit = HTP_COMPRESSION_BOMB_LIMIT;
+    cfg->compression_time_limit = HTP_COMPRESSION_TIME_LIMIT_USEC;
 
     // Default settings for URL-encoded data.
 
@@ -520,6 +521,16 @@ void htp_config_set_compression_bomb_limit(htp_cfg_t *cfg, size_t bomblimit) {
         cfg->compression_bomb_limit = INT32_MAX;
     } else {
         cfg->compression_bomb_limit = bomblimit;
+    }
+}
+
+void htp_config_set_compression_time_limit(htp_cfg_t *cfg, size_t useclimit) {
+    if (cfg == NULL) return;
+    // max limit is one second
+    if (useclimit >= 1000000) {
+        cfg->compression_time_limit = 1000000;
+    } else {
+        cfg->compression_time_limit = useclimit;
     }
 }
 

--- a/htp/htp_config.h
+++ b/htp/htp_config.h
@@ -443,6 +443,14 @@ void htp_config_set_lzma_memlimit(htp_cfg_t *cfg, size_t memlimit);
 void htp_config_set_compression_bomb_limit(htp_cfg_t *cfg, size_t bomblimit);
 
 /**
+ * Configures the maximum compression bomb time LibHTP will decompress.
+ *
+ * @param[in] cfg
+ * @param[in] useclimit
+ */
+void htp_config_set_compression_time_limit(htp_cfg_t *cfg, size_t useclimit);
+
+/**
  * Configures the desired log level.
  * 
  * @param[in] cfg

--- a/htp/htp_config_private.h
+++ b/htp/htp_config_private.h
@@ -348,6 +348,9 @@ struct htp_cfg_t {
 
     /** max output size for a compression bomb. */
     int32_t compression_bomb_limit;
+
+    /** max time for a decompression bomb. */
+    int32_t compression_time_limit;
 };
 
 #ifdef	__cplusplus

--- a/htp/htp_decompressors.h
+++ b/htp/htp_decompressors.h
@@ -59,6 +59,9 @@ struct htp_decompressor_t {
     htp_status_t (*callback)(htp_tx_data_t *);
     void (*destroy)(htp_decompressor_t *);
     struct htp_decompressor_t *next;
+    struct timeval time_before;
+    int32_t time_spent;
+    uint32_t nb_callbacks;
 };
 
 struct htp_decompressor_gzip_t {

--- a/htp/htp_private.h
+++ b/htp/htp_private.h
@@ -83,6 +83,10 @@ extern "C" {
 //deflate max ratio is about 1000
 #define HTP_COMPRESSION_BOMB_RATIO          2048
 #define HTP_COMPRESSION_BOMB_LIMIT          1048576
+// 0.1 second
+#define HTP_COMPRESSION_TIME_LIMIT_USEC     100000
+// test time for compression every 256 callbacks
+#define HTP_COMPRESSION_TIME_FREQ_TEST      256
 
 #define HTP_FIELD_LIMIT_HARD               18000
 #define HTP_FIELD_LIMIT_SOFT               9000


### PR DESCRIPTION
To avoid DOS by small repeated zip bombs or big lzma bomb

Modifies #289 with
- use of new portable function `htp_timer_track` instead of `timeradd` and such