### PR TITLE
htp.pc.in: add -lz to Libs.private

### DIFF
--- a/htp.pc.in
+++ b/htp.pc.in
@@ -7,6 +7,6 @@ Name: @PACKAGE_NAME@
 Description: A security-aware HTTP parser, designed for use in IDS/IPS and WAF products.
 Version: @PACKAGE_VERSION@
 Libs: -L${libdir} -lhtp
-Libs.private: @LIBICONV@
+Libs.private: -lz @LIBICONV@
 Cflags: -I${includedir} -I${libdir}/htp/include
 


### PR DESCRIPTION
zlib is a mandatory dependency so add it to Libs.private otherwise
static linking of packages linking with htp (e.g. suricata) will fail.

[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/libhtp/0002-htp.pc.in-add-lz-to-Libs.private.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>