### PR TITLE
Gap handling 3359 v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ compiler:
   - gcc
   - clang
 # Change this to your needs
-script: sh autogen.sh && ./configure && make && make check && make distcheck
+script: sh autogen.sh && ./configure && make && (make check || cat test/test-suite.log) && make distcheck
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y build-essential autoconf automake libtool zlib1g zlib1g-dev make 

--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -775,6 +775,10 @@ htp_status_t htp_connp_REQ_LINE_complete(htp_connp_t *connp) {
     #ifdef HTP_DEBUG
     fprint_raw_data(stderr, __func__, data, len);
     #endif
+    if (len == 0) {
+        htp_connp_req_clear_buffer(connp);
+        return HTP_DATA;
+    }
 
     // Is this a line that should be ignored?
     if (htp_connp_is_line_ignorable(connp, data, len)) {

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -1228,7 +1228,7 @@ int htp_connp_res_data(htp_connp_t *connp, const htp_time_t *timestamp, const vo
     // only if the stream has been closed. We do not allow zero-sized
     // chunks in the API, but we use it internally to force the parsers
     // to finalize parsing.
-    if (((data == NULL) || (len == 0)) && (connp->out_status != HTP_STREAM_CLOSED)) {
+    if (len == 0 && connp->out_status != HTP_STREAM_CLOSED) {
         htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0, "Zero-length data chunks are not allowed");
 
         #ifdef HTP_DEBUG
@@ -1277,7 +1277,22 @@ int htp_connp_res_data(htp_connp_t *connp, const htp_time_t *timestamp, const vo
         // or if we've run out of data. We are relying
         // on processors to add error messages, so we'll
         // keep quiet here.
-        htp_status_t rc = connp->out_state(connp);
+        htp_status_t rc;
+
+        //handle gap
+        if (data == NULL && len > 0) {
+            if (connp->out_state == htp_connp_RES_BODY_IDENTITY_CL_KNOWN ||
+                connp->out_state == htp_connp_RES_BODY_IDENTITY_STREAM_CLOSE) {
+                rc = connp->out_state(connp);
+            } else if (connp->out_state == htp_connp_RES_FINALIZE) {
+                rc = htp_tx_state_response_complete_ex(connp->out_tx, 0);
+            } else {
+                htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0, "Gaps are not allowed during this state");
+                return HTP_STREAM_CLOSED;
+            }
+        } else {
+            rc = connp->out_state(connp);
+        }
         if (rc == HTP_OK) {
             if (connp->out_status == HTP_STREAM_TUNNEL) {
                 #ifdef HTP_DEBUG


### PR DESCRIPTION
Redmine ticket :
https://redmine.openinfosecfoundation.org/issues/3559

Suricata PR https://github.com/OISF/suricata/pull/4951

Should there be some documentation to change ? (This somehow changes/extends the API behavior)

Modifies #297 by 
- having a verbose output from Travis when a test fails
- fixing handling empty input (`len == 0`) in `htp_connp_REQ_LINE_complete`

The later bug is unrelated and was already present.
I guess ubsan got upgraded lately, and noticed we have a `memcpy(x, NULL, 0);` in the unit test `HybridParsing.DeleteTransactionBeforeComplete` (should not be reachable by Suricata) from `connp->in_tx->request_line = bstr_dup_mem(data, len);`

linked with 
https://github.com/OISF/suricata/pull/5172
https://github.com/OISF/suricata-verify/pull/282
