### PR TITLE
decompression: limit lzma layers to one

### DIFF
--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -1280,6 +1280,7 @@ htp_status_t htp_tx_state_response_headers(htp_tx_t *tx) {
         } else {
             int layers = 0;
             htp_decompressor_t *comp = NULL;
+            int nblzma = 0;
 
             uint8_t *tok = NULL;
             size_t tok_len = 0;
@@ -1326,6 +1327,12 @@ htp_status_t htp_tx_state_response_headers(htp_tx_t *tx) {
                     cetype = HTP_COMPRESSION_DEFLATE;
                 } else if (bstr_util_cmp_mem(tok, tok_len, "lzma", 4) == 0) {
                     cetype = HTP_COMPRESSION_LZMA;
+                    nblzma++;
+                    if (nblzma > 1) {
+                        htp_log(tx->connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                                "Compression bomb: double lzma encoding");
+                        break;
+                    }
                 } else if (bstr_util_cmp_mem(tok, tok_len, "inflate", 7) == 0) {
                     cetype = HTP_COMPRESSION_NONE;
                 } else {


### PR DESCRIPTION
and log an error if there are more

cf https://redmine.openinfosecfoundation.org/issues/3776