### PR TITLE
decompression: configurable limit for lzma layers

### DIFF
--- a/htp/htp_config.c
+++ b/htp/htp_config.c
@@ -159,6 +159,7 @@ htp_cfg_t *htp_config_create(void) {
     cfg->extract_request_files_limit = -1; // Use the parser default.
     cfg->response_decompression_layer_limit = 2; // 2 layers seem fairly common
     cfg->lzma_memlimit = HTP_LZMA_MEMLIMIT;
+    cfg->response_lzma_layer_limit = 1; // default is only one layer
     cfg->compression_bomb_limit = HTP_COMPRESSION_BOMB_LIMIT;
     cfg->compression_time_limit = HTP_COMPRESSION_TIME_LIMIT_USEC;
 
@@ -513,6 +514,11 @@ void htp_config_set_field_limits(htp_cfg_t *cfg, size_t soft_limit, size_t hard_
 void htp_config_set_lzma_memlimit(htp_cfg_t *cfg, size_t memlimit) {
     if (cfg == NULL) return;
     cfg->lzma_memlimit = memlimit;
+}
+
+void htp_config_set_lzma_layers(htp_cfg_t *cfg, int limit) {
+    if (cfg == NULL) return;
+    cfg->response_lzma_layer_limit = limit;
 }
 
 void htp_config_set_compression_bomb_limit(htp_cfg_t *cfg, size_t bomblimit) {

--- a/htp/htp_config.h
+++ b/htp/htp_config.h
@@ -435,6 +435,14 @@ void htp_config_set_field_limits(htp_cfg_t *cfg, size_t soft_limit, size_t hard_
 void htp_config_set_lzma_memlimit(htp_cfg_t *cfg, size_t memlimit);
 
 /**
+ * Configures the maximum layers LibHTP will pass to liblzma.
+ *
+ * @param[in] cfg
+ * @param[in] limit
+ */
+void htp_config_set_lzma_layers(htp_cfg_t *cfg, int limit);
+
+/**
  * Configures the maximum compression bomb size LibHTP will decompress.
  *
  * @param[in] cfg

--- a/htp/htp_config_private.h
+++ b/htp/htp_config_private.h
@@ -351,6 +351,9 @@ struct htp_cfg_t {
 
     /** max time for a decompression bomb. */
     int32_t compression_time_limit;
+
+    /** How many layers of compression we will decompress (0 => no lzma). */
+    int response_lzma_layer_limit;
 };
 
 #ifdef	__cplusplus

--- a/htp/htp_decompressors.c
+++ b/htp/htp_decompressors.c
@@ -439,7 +439,8 @@ htp_decompressor_t *htp_gzip_decompressor_create(htp_connp_t *connp, enum htp_co
 
     switch (format) {
         case HTP_COMPRESSION_LZMA:
-            if (connp->cfg->lzma_memlimit > 0) {
+            if (connp->cfg->lzma_memlimit > 0 &&
+                connp->cfg->response_lzma_layer_limit > 0) {
                 LzmaDec_Construct(&drec->state);
             } else {
                 htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "LZMA decompression disabled");

--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -1280,6 +1280,7 @@ htp_status_t htp_tx_state_response_headers(htp_tx_t *tx) {
         } else {
             int layers = 0;
             htp_decompressor_t *comp = NULL;
+            int nblzma = 0;
 
             uint8_t *tok = NULL;
             size_t tok_len = 0;
@@ -1326,6 +1327,12 @@ htp_status_t htp_tx_state_response_headers(htp_tx_t *tx) {
                     cetype = HTP_COMPRESSION_DEFLATE;
                 } else if (bstr_util_cmp_mem(tok, tok_len, "lzma", 4) == 0) {
                     cetype = HTP_COMPRESSION_LZMA;
+                    nblzma++;
+                    if (nblzma > tx->connp->cfg->response_lzma_layer_limit) {
+                        htp_log(tx->connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
+                                "Compression bomb: double lzma encoding");
+                        break;
+                    }
                 } else if (bstr_util_cmp_mem(tok, tok_len, "inflate", 7) == 0) {
                     cetype = HTP_COMPRESSION_NONE;
                 } else {


### PR DESCRIPTION
Default value is one.
Log an error if there are more lzma layers.

Replaces https://github.com/OISF/libhtp/pull/303 by taking comment into account

https://redmine.openinfosecfoundation.org/issues/3776
cf https://github.com/OISF/suricata/pull/5389