### PR TITLE
Http expect100 3880 v2

### DIFF
--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -886,12 +886,18 @@ htp_status_t htp_connp_REQ_FINALIZE(htp_connp_t *connp) {
             bstr_free(method);
         }
         if (methodi == HTP_M_UNKNOWN) {
+            if (connp->in_body_data_left <= 0) {
+                // log only once per transaction
+                htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Unexpected request body");
+            } else {
+                connp->in_body_data_left = 1;
+            }
             // Interpret remaining bytes as body data
-            htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Unexpected request body");
             htp_status_t rc = htp_tx_req_process_body_data_ex(connp->in_tx, data, len);
             htp_connp_req_clear_buffer(connp);
             return rc;
         } // else continue
+        connp->in_body_data_left = -1;
     }
     //unread last end of line so that REQ_LINE works
     if (connp->in_current_read_offset < (int64_t)len) {

--- a/test/files/99-expect-100.t
+++ b/test/files/99-expect-100.t
@@ -1,0 +1,28 @@
+>>>
+PUT /forbidden HTTP/1.1
+Content-Length: 14
+Expect: 100-continue
+
+
+<<<
+HTTP/1.0 401 Forbidden
+Content-Length: 0
+
+
+>>>
+POST /ok HTTP/1.1
+Content-Length: 14
+Expect: 100-continue
+
+
+<<<
+HTTP/1.0 100 continue
+
+
+>>>
+Hello People!
+
+<<<
+HTTP/1.0 200 OK
+
+

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -2068,3 +2068,23 @@ TEST_F(ConnectionParsing, ResponsesCut) {
     ASSERT_EQ(200, tx->response_status_number);
     ASSERT_EQ(HTP_RESPONSE_COMPLETE, tx->response_progress);
 }
+
+TEST_F(ConnectionParsing, Expect100) {
+    int rc = test_run(home, "99-expect-100.t", cfg, &connp);
+    ASSERT_GE(rc, 0);
+
+    ASSERT_EQ(2, htp_list_size(connp->conn->transactions));
+    htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
+    ASSERT_TRUE(tx != NULL);
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "PUT"));
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+    ASSERT_EQ(401, tx->response_status_number);
+    ASSERT_EQ(HTP_RESPONSE_COMPLETE, tx->response_progress);
+
+    tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 1);
+    ASSERT_TRUE(tx != NULL);
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "POST"));
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+    ASSERT_EQ(200, tx->response_status_number);
+    ASSERT_EQ(HTP_RESPONSE_COMPLETE, tx->response_progress);
+}


### PR DESCRIPTION
https://redmine.openinfosecfoundation.org/issues/3880

Handles expect 100-continue header And limits some logging