### PR TITLE
Http expect100 3880 v3

### DIFF
--- a/test/files/99-expect-100.t
+++ b/test/files/99-expect-100.t
@@ -1,0 +1,28 @@
+>>>
+PUT /forbidden HTTP/1.1
+Content-Length: 14
+Expect: 100-continue
+
+
+<<<
+HTTP/1.0 401 Forbidden
+Content-Length: 0
+
+
+>>>
+POST /ok HTTP/1.1
+Content-Length: 14
+Expect: 100-continue
+
+
+<<<
+HTTP/1.0 100 continue
+
+
+>>>
+Hello People!
+
+<<<
+HTTP/1.0 200 OK
+
+

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -2068,3 +2068,23 @@ TEST_F(ConnectionParsing, ResponsesCut) {
     ASSERT_EQ(200, tx->response_status_number);
     ASSERT_EQ(HTP_RESPONSE_COMPLETE, tx->response_progress);
 }
+
+TEST_F(ConnectionParsing, Expect100) {
+    int rc = test_run(home, "99-expect-100.t", cfg, &connp);
+    ASSERT_GE(rc, 0);
+
+    ASSERT_EQ(2, htp_list_size(connp->conn->transactions));
+    htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
+    ASSERT_TRUE(tx != NULL);
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "PUT"));
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+    ASSERT_EQ(401, tx->response_status_number);
+    ASSERT_EQ(HTP_RESPONSE_COMPLETE, tx->response_progress);
+
+    tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 1);
+    ASSERT_TRUE(tx != NULL);
+    ASSERT_EQ(0, bstr_cmp_c(tx->request_method, "POST"));
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+    ASSERT_EQ(200, tx->response_status_number);
+    ASSERT_EQ(HTP_RESPONSE_COMPLETE, tx->response_progress);
+}


### PR DESCRIPTION
https://redmine.openinfosecfoundation.org/issues/3880

Handles expect 100-continue header And limits some logging

Replaces #306 with needed rebasing