### PR TITLE
Allows space in URI until the last space

### DIFF
--- a/htp/htp_config.c
+++ b/htp/htp_config.c
@@ -162,6 +162,7 @@ htp_cfg_t *htp_config_create(void) {
     cfg->response_lzma_layer_limit = 1; // default is only one layer
     cfg->compression_bomb_limit = HTP_COMPRESSION_BOMB_LIMIT;
     cfg->compression_time_limit = HTP_COMPRESSION_TIME_LIMIT_USEC;
+    cfg->allow_space_uri = 0;
 
     // Default settings for URL-encoded data.
 
@@ -558,6 +559,11 @@ void htp_config_set_parse_request_cookies(htp_cfg_t *cfg, int parse_request_cook
 void htp_config_set_response_decompression(htp_cfg_t *cfg, int enabled) {
     if (cfg == NULL) return;
     cfg->response_decompression_enabled = enabled;
+}
+
+void htp_config_set_allow_space_uri(htp_cfg_t *cfg, int allow_space_uri) {
+    if (cfg == NULL) return;
+    cfg->allow_space_uri = allow_space_uri;
 }
 
 int htp_config_set_server_personality(htp_cfg_t *cfg, enum htp_server_personality_t personality) {

--- a/htp/htp_config.h
+++ b/htp/htp_config.h
@@ -523,6 +523,14 @@ void htp_config_set_parse_request_auth(htp_cfg_t *cfg, int parse_request_auth);
 void htp_config_set_parse_request_cookies(htp_cfg_t *cfg, int parse_request_cookies);
 
 /**
+ * Enable or disable spaces in URIs. Disabled by default.
+ *
+ * @param[in] cfg
+ * @param[in] allow_space_uri
+ */
+void htp_config_set_allow_space_uri(htp_cfg_t *cfg, int allow_space_uri);
+
+/**
  * Configures whether consecutive path segment separators will be compressed. When enabled, a path
  * such as "/one//two" will be normalized to "/one/two". Backslash conversion and path segment separator
  * decoding are carried out before compression. For example, the path "/one\\/two\/%5cthree/%2f//four"

--- a/htp/htp_config_private.h
+++ b/htp/htp_config_private.h
@@ -193,6 +193,9 @@ struct htp_cfg_t {
     /** How many extracted files are allowed in a single Multipart request? */
     int extract_request_files_limit;
 
+    /** Whether to allow spaces in URI. */
+    int allow_space_uri;
+
     /** The location on disk where temporary files will be created. */
     char *tmpdir;
 


### PR DESCRIPTION
Fixes https://redmine.openinfosecfoundation.org/issues/2881

It is less likely that spaces are added in protocol than in URIs

Modifies #264 : rebased