### PR TITLE
util: fix null-dereference warning found by coverity

### DIFF
--- a/htp/htp_util.c
+++ b/htp/htp_util.c
@@ -1976,7 +1976,7 @@ void fprint_bstr(FILE *stream, const char *name, bstr *b) {
  */
 void fprint_raw_data(FILE *stream, const char *name, const void *data, size_t len) {
     // may happen for gaps
-    if (data == NULL && len > 0) {
+    if (data == NULL) {
         fprintf(stream, "\n%s: ptr NULL len %u\n", name, (unsigned int)len);
     } else {
         fprint_raw_data_ex(stream, name, data, 0, len);


### PR DESCRIPTION
I think this is kind of a false positive as `fprintf` will accept a NULL string... But it may be better to fix this