### PR TITLE
Gap finalize before 4219 v1

### DIFF
--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -1103,6 +1103,10 @@ htp_status_t htp_tx_state_response_complete_ex(htp_tx_t *tx, int hybrid_mode) {
         // Run hook RESPONSE_COMPLETE.
         htp_status_t rc = htp_hook_run_all(tx->connp->cfg->hook_response_complete, tx);
         if (rc != HTP_OK) return rc;
+
+        // Clear the out data receiver hook if any
+        rc = htp_connp_res_receiver_finalize_clear(tx->connp);
+        if (rc != HTP_OK) return rc;
     }
 
     if (!hybrid_mode) {

--- a/test/fuzz/fuzz_htp.c
+++ b/test/fuzz/fuzz_htp.c
@@ -68,7 +68,7 @@ static int HTPCallbackResponseHasTrailer(htp_tx_t *tx)
 static int HTPCallbackRequestBodyData(htp_tx_data_t *tx_data)
 {
     fprintf(logfile, "HTPCallbackRequestBodyData %"PRIuMAX"\n", (uintmax_t)tx_data->len);
-    if (tx_data->len > 0) {
+    if (tx_data->len > 0 && tx_data->data != NULL) {
         fprintf(logfile, "HTPCallbackRequestBodyData %x %x\n", tx_data->data[0], tx_data->data[(uintmax_t)tx_data->len-1]);
     }
     return 0;
@@ -77,7 +77,7 @@ static int HTPCallbackRequestBodyData(htp_tx_data_t *tx_data)
 static int HTPCallbackResponseBodyData(htp_tx_data_t *tx_data)
 {
     fprintf(logfile, "HTPCallbackResponseBodyData %"PRIuMAX"\n", (uintmax_t)tx_data->len);
-    if (tx_data->len > 0) {
+    if (tx_data->len > 0 && tx_data->data != NULL) {
         fprintf(logfile, "HTPCallbackResponseBodyData %x %x\n", tx_data->data[0], tx_data->data[(uintmax_t)tx_data->len-1]);
     }
     return 0;

--- a/test/test.c
+++ b/test/test.c
@@ -73,7 +73,7 @@ static int test_is_boundary(test_t *test, size_t pos) {
     // Check that there's enough room
     if (pos + 3 >= test->len) return -1;
 
-    if ((test->buf[pos] == '<') && (test->buf[pos + 1] == '<') && (test->buf[pos + 2] == '<')) {
+    if ((test->buf[pos] == '<') && (test->buf[pos + 1] == '<' || test->buf[pos + 1] == '>') && (test->buf[pos + 2] == '<')) {
         if (test->buf[pos + 3] == '\n') {
             return SERVER;
         }
@@ -86,7 +86,7 @@ static int test_is_boundary(test_t *test, size_t pos) {
         }
     }
 
-    if ((test->buf[pos] == '>') && (test->buf[pos + 1] == '>') && (test->buf[pos + 2] == '>')) {
+    if ((test->buf[pos] == '>') && (test->buf[pos + 1] == '>' || test->buf[pos + 1] == '<') && (test->buf[pos + 2] == '>')) {
         if (test->buf[pos + 3] == '\n') {
             return CLIENT;
         }
@@ -207,6 +207,10 @@ int test_next_chunk(test_t *test) {
                 // which belongs to the next boundary
                 if ((test->chunk_len > 0) && (test->chunk[test->chunk_len - 1] == '\r')) {
                     test->chunk_len--;
+                }
+                if (test->buf[test->pos + 1] != test->buf[test->pos + 2]) {
+                    // test gap
+                    test->chunk = NULL;
                 }
 
                 // Position at the next boundary line


### PR DESCRIPTION
https://redmine.openinfosecfoundation.org/issues/4219

- Adds gaps in fuzz testing
- Fixes root bug in leading to NULL dereference in suricata, ie clearing out_data_receiver_hook at transaction end if it was not the case