### PR TITLE
Gap finalize before 4219 v2

### DIFF
--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -113,12 +113,12 @@ static htp_status_t htp_connp_req_receiver_send_data(htp_connp_t *connp, int is_
  * @return HTP_OK, or a value returned from a callback.
  */
 static htp_status_t htp_connp_req_receiver_set(htp_connp_t *connp, htp_hook_t *data_receiver_hook) {
-    htp_connp_req_receiver_finalize_clear(connp);
+    htp_status_t rc = htp_connp_req_receiver_finalize_clear(connp);
 
     connp->in_data_receiver_hook = data_receiver_hook;
     connp->in_current_receiver_offset = connp->in_current_read_offset;
 
-    return HTP_OK;
+    return rc;
 }
 
 /**

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -132,12 +132,12 @@ htp_status_t htp_connp_res_receiver_finalize_clear(htp_connp_t *connp) {
  * @return HTP_OK, or a value returned from a callback.
  */
 static htp_status_t htp_connp_res_receiver_set(htp_connp_t *connp, htp_hook_t *data_receiver_hook) {
-    htp_connp_res_receiver_finalize_clear(connp);
+    htp_status_t rc = htp_connp_res_receiver_finalize_clear(connp);
 
     connp->out_data_receiver_hook = data_receiver_hook;
     connp->out_current_receiver_offset = connp->out_current_read_offset;
 
-    return HTP_OK;
+    return rc;
 }
 
 /**

--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -1104,8 +1104,11 @@ htp_status_t htp_tx_state_response_complete_ex(htp_tx_t *tx, int hybrid_mode) {
         htp_status_t rc = htp_hook_run_all(tx->connp->cfg->hook_response_complete, tx);
         if (rc != HTP_OK) return rc;
 
-        // Clear the out data receiver hook if any
+        // Clear the data receivers hook if any
         rc = htp_connp_res_receiver_finalize_clear(tx->connp);
+        if (rc != HTP_OK) return rc;
+
+        rc = htp_connp_req_receiver_finalize_clear(tx->connp);
         if (rc != HTP_OK) return rc;
     }
 

--- a/test/fuzz/fuzz_htp.c
+++ b/test/fuzz/fuzz_htp.c
@@ -201,7 +201,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
             }
         } else {
             if (out_data_other) {
-                rc = htp_connp_res_data(connp, NULL, out_data + out_data_offset, out_data_len - out_data_offset);
+                if (out_data == NULL) {
+                    rc = htp_connp_res_data(connp, NULL, NULL, out_data_len - out_data_offset);
+                } else {
+                    rc = htp_connp_res_data(connp, NULL, out_data + out_data_offset, out_data_len - out_data_offset);
+                }
                 if (rc == HTP_STREAM_ERROR) {
                     break;
                 }
@@ -220,7 +224,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
                 out_data_offset = htp_connp_res_data_consumed(connp);
             }
             if (in_data_other) {
-                rc = htp_connp_req_data(connp, NULL, in_data + in_data_offset, in_data_len - in_data_offset);
+                if (in_data == NULL) {
+                    rc = htp_connp_req_data(connp, NULL, NULL, in_data_len - in_data_offset);
+                } else {
+                    rc = htp_connp_req_data(connp, NULL, in_data + in_data_offset, in_data_len - in_data_offset);
+                }
                 if (rc == HTP_STREAM_ERROR) {
                     break;
                 }
@@ -229,7 +237,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
         }
     }
     if (out_data_other) {
-        htp_connp_res_data(connp, NULL, out_data + out_data_offset, out_data_len - out_data_offset);
+        if (out_data == NULL) {
+            rc = htp_connp_res_data(connp, NULL, NULL, out_data_len - out_data_offset);
+        } else {
+            htp_connp_res_data(connp, NULL, out_data + out_data_offset, out_data_len - out_data_offset);
+        }
     }
 
     htp_connp_close(connp, NULL);


### PR DESCRIPTION
Completing fix for https://redmine.openinfosecfoundation.org/issues/4219

- fixing the fuzz target for gaps
- handling the in data receiver hook as the out one
- fixing covert unchecked return values (present before)