### PR TITLE
time: do not put the whole stream in error state

### DIFF
--- a/htp/htp_decompressors.c
+++ b/htp/htp_decompressors.c
@@ -189,7 +189,7 @@ static htp_status_t htp_gzip_decompressor_decompress(htp_decompressor_gzip_t *dr
 
     // Pass-through the NULL chunk, which indicates the end of the stream.
 
-    if (drec->passthrough) {
+    if (drec->super.passthrough) {
         htp_tx_data_t d2;
         d2.tx = d->tx;
         d2.data = d->data;
@@ -391,7 +391,7 @@ restart:
             drec->stream.next_out = drec->buffer;
 
             /* successfully passed through, lets continue doing that */
-            drec->passthrough = 1;
+            drec->super.passthrough = 1;
             return HTP_OK;
         }
     }
@@ -444,7 +444,7 @@ htp_decompressor_t *htp_gzip_decompressor_create(htp_connp_t *connp, enum htp_co
                 LzmaDec_Construct(&drec->state);
             } else {
                 htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "LZMA decompression disabled");
-                drec->passthrough = 1;
+                drec->super.passthrough = 1;
             }
             rc = Z_OK;
             break;

--- a/htp/htp_decompressors.h
+++ b/htp/htp_decompressors.h
@@ -62,6 +62,7 @@ struct htp_decompressor_t {
     struct timeval time_before;
     int32_t time_spent;
     uint32_t nb_callbacks;
+    uint8_t passthrough;    /**< decompression failed, pass through raw data */
 };
 
 struct htp_decompressor_gzip_t {
@@ -71,7 +72,6 @@ struct htp_decompressor_gzip_t {
     #endif
     int zlib_initialized;
     uint8_t restart;    /**< deflate restarted to try rfc1950 instead of 1951 */
-    uint8_t passthrough;    /**< decompression failed, pass through raw data */
     z_stream stream;
     uint8_t header[LZMA_PROPS_SIZE + 8];
     uint8_t header_len;

--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -886,7 +886,7 @@ static htp_status_t htp_tx_req_process_body_data_decompressor_callback(htp_tx_da
                 htp_log(d->tx->connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
                         "Compression bomb: spent %"PRId64" us decompressing",
                         d->tx->connp->req_decompressor->time_spent);
-                return HTP_ERROR;
+                d->tx->connp->req_decompressor->passthrough = 1;
             }
         }
 
@@ -927,7 +927,7 @@ static htp_status_t htp_tx_res_process_body_data_decompressor_callback(htp_tx_da
                 htp_log(d->tx->connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
                         "Compression bomb: spent %"PRId64" us decompressing",
                         d->tx->connp->out_decompressor->time_spent);
-                return HTP_ERROR;
+                d->tx->connp->out_decompressor->passthrough = 1;
             }
         }
 
@@ -989,7 +989,7 @@ htp_status_t htp_tx_res_process_body_data_ex(htp_tx_t *tx, const void *data, siz
                     htp_log(tx->connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0,
                             "Compression bomb: spent %"PRId64" us decompressing",
                             tx->connp->out_decompressor->time_spent);
-                    return HTP_ERROR;
+                    tx->connp->out_decompressor->passthrough = 1;
                 }
             }
 


### PR DESCRIPTION
in case we reached some time limit
just set the decompressor in passthrough mode

https://redmine.openinfosecfoundation.org/issues/4331