### PR TITLE
Differential fuzzing against rust version

### DIFF
--- a/htp/htp_util.c
+++ b/htp/htp_util.c
@@ -219,7 +219,7 @@ int htp_convert_method_to_number(bstr *method) {
  * @return 0 or 1
  */
 int htp_is_line_empty(unsigned char *data, size_t len) {
-    if ((len == 1) ||
+    if (((len == 1) && ((data[0] == CR) || (data[0] == LF))) ||
         ((len == 2) && (data[0] == CR) && (data[1] == LF))) {
         return 1;
     }

--- a/test/fuzz/fuzz_diff.c
+++ b/test/fuzz/fuzz_diff.c
@@ -17,12 +17,13 @@
 #include "htp/htp.h"
 #include "test/test.h"
 #include "fuzz_htp.h"
+#include "htp/htp_private.h"
 
 FILE * logfile = NULL;
 
 
 /**
- * Invoked at the end of every transaction. 
+ * Invoked at the end of every transaction.
  *
  * @param[in] connp
  */
@@ -108,7 +109,7 @@ static int HTPCallbackRequestLine(htp_tx_t *tx)
 }
 
 /**
- * Invoked every time LibHTP wants to log. 
+ * Invoked every time LibHTP wants to log.
  *
  * @param[in] log
  */
@@ -125,25 +126,18 @@ void fuzz_openFile(const char * name) {
     logfile = fopen(name, "w");
 }
 
-int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
-    htp_cfg_t *cfg;
-    htp_connp_t * connp;
-    int rc;
-    test_t test;
+htp_cfg_t *cfg;
 
-    //initialize output file
+static void libhtpFuzzInit() {
+    logfile = fopen("/dev/null", "w");
     if (logfile == NULL) {
-        logfile = fopen("/dev/null", "w");
-        if (logfile == NULL) {
-            abort();
-        }
+        abort();
     }
-
     // Create LibHTP configuration
     cfg = htp_config_create();
     if (htp_config_set_server_personality(cfg, HTP_SERVER_IDS) != HTP_OK) {
         htp_config_destroy(cfg);
-        return 0;
+        return;
     }
     htp_config_register_log(cfg, HTPCallbackLog);
     htp_config_register_request_header_data(cfg, HTPCallbackRequestHeaderData);
@@ -159,6 +153,13 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     htp_config_register_response_start(cfg, HTPCallbackResponseStart);
     htp_config_register_response_complete(cfg, HTPCallbackResponse);
     htp_config_register_request_line(cfg, HTPCallbackRequestLine);
+    setenv("srcdir", ".", 1);
+}
+
+static htp_connp_t * libhtpFuzzRun(const uint8_t *Data, size_t Size) {
+    htp_connp_t * connp;
+    int rc;
+    test_t test;
 
     connp = htp_connp_create(cfg);
     htp_connp_set_user_data(connp, (void *) 0x02);
@@ -248,9 +249,183 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     }
 
     htp_connp_close(connp, NULL);
+    return connp;
+}
+
+void* libhtprsFuzzRun(const uint8_t *Data, uint32_t Size);
+void* libhtprsFuzzConnp(void *);
+size_t htp_connp__rstx_size(void *);
+void * htp_connp__rstx(void *, size_t);
+void * htp_tx_request_method(void *);
+void * htp_tx_request_uri(void *);
+void * htp_tx_request_protocol(void *);
+void * htp_tx_response_protocol(void *);
+void * htp_tx_response_status(void *);
+size_t htp_tx_request_headers_size(void *);
+void *htp_tx_request_header_index(void *, size_t);
+size_t htp_tx_response_headers_size(void *);
+void *htp_tx_response_header_index(void *, size_t);
+void * htp_header_name(void *);
+void * htp_header_value(void *);
+size_t bstr_len_rs(void *);
+uint8_t * bstr_ptr_rs(void *);
+void libhtprsFreeFuzzRun(void *t);
+
+static int bstrDiff(void* rsbstr, bstr * cbstr, const char *field) {
+    if (rsbstr == NULL && cbstr == NULL) {
+        return 0;
+    }
+    size_t len =  bstr_len(cbstr);
+    uint8_t * rsptr = bstr_ptr_rs(rsbstr);
+    uint8_t * cptr = bstr_ptr(cbstr);
+    if (bstr_len_rs(rsbstr) != len) {
+        fprint_raw_data(stdout, "c=", cptr, len);
+        fprint_raw_data(stdout, "rust=", rsptr, bstr_len_rs(rsbstr));
+        printf("Assertion failure: Bstr %s lengths are different %zu vs %zu\n", field, bstr_len_rs(rsbstr), len);
+        return 1;
+    }
+    for (size_t i=0; i<len; i++) {
+        if (rsptr[i] != cptr[i]) {
+            fprint_raw_data(stdout, "c=", cptr, len);
+            fprint_raw_data(stdout, "rust=", rsptr, bstr_len_rs(rsbstr));
+            printf("Assertion failure: Bstr %s index %zu are different %02x vs %02x\n", field, i, rsptr[i], cptr[i]);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int txDiff(void* rstx, htp_tx_t * ctx) {
+    if (bstrDiff(htp_tx_request_method(rstx), ctx->request_method, "methods")) {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        abort();
+#endif
+        return 1;
+    }
+    if (bstrDiff(htp_tx_request_uri(rstx), ctx->request_uri, "uri")) {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        abort();
+#endif
+        return 1;
+    }
+    if (bstrDiff(htp_tx_request_protocol(rstx), ctx->request_protocol, "protocol_request")) {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        abort();
+#endif
+        return 1;
+    }
+    if (bstrDiff(htp_tx_response_protocol(rstx), ctx->response_protocol, "protocol_response")) {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        abort();
+#endif
+        return 1;
+    }
+    if (bstrDiff(htp_tx_response_status(rstx), ctx->response_status, "status")) {
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        abort();
+#endif
+        return 1;
+    }
+
+    uint32_t nbhc = htp_table_size(ctx->request_headers);
+    uint32_t rsnbh = htp_tx_request_headers_size(rstx);
+    if (rsnbh != nbhc) {
+        printf("Assertion failure: got nbheaders c=%d versus rust=%d\n", nbhc, rsnbh);
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        abort();
+#endif
+        return 1;
+    }
+
+    for (uint32_t i = 0; i < nbhc; i++) {
+        htp_header_t *h = (htp_header_t *) htp_table_get_index(ctx->request_headers, i, NULL);
+        void *rsh = htp_tx_request_header_index(rstx, (size_t) i);
+        if (bstrDiff(htp_header_name(rsh), h->name, "header-name")) {
+            printf("request header %d is different\n", i);
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+            abort();
+#endif
+            return 1;
+        }
+        if (bstrDiff(htp_header_value(rsh), h->value, "header-value")) {
+            printf("request header %d is different\n", i);
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+            abort();
+#endif
+            return 1;
+        }
+    }
+
+    nbhc = htp_table_size(ctx->response_headers);
+    rsnbh = htp_tx_response_headers_size(rstx);
+    if (rsnbh != nbhc) {
+        printf("Assertion failure: got nbheaders c=%d versus rust=%d\n", nbhc, rsnbh);
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        abort();
+#endif
+        return 1;
+    }
+
+    for (uint32_t i = 0; i < nbhc; i++) {
+        htp_header_t *h = (htp_header_t *) htp_table_get_index(ctx->response_headers, i, NULL);
+        void *rsh = htp_tx_response_header_index(rstx, (size_t) i);
+        if (bstrDiff(htp_header_name(rsh), h->name, "header-name")) {
+            printf("response header %d is different\n", i);
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+            abort();
+#endif
+            return 1;
+        }
+        if (bstrDiff(htp_header_value(rsh), h->value, "header-value")) {
+            printf("response header %d is different\n", i);
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+            abort();
+#endif
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+static int connDiff(void* rsconnp, htp_conn_t * conn) {
+    uint32_t rs = htp_connp__rstx_size(rsconnp);
+    uint32_t c = htp_list_size(conn->transactions);
+    if (rs != c) {
+        printf("Assertion failure: got nbtx c=%d versus rust=%d\n", c, rs);
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+        abort();
+#endif
+        return 1;
+    }
+    for (uint32_t i = 0; i < c; i++) {
+        htp_tx_t *ctx = (htp_tx_t *) htp_list_get(conn->transactions, i);
+        void *rstx = htp_connp__rstx(rsconnp, (size_t) i);
+        if (txDiff(rstx, ctx)) {
+            printf("tx %d is different\n", i);
+            return 1;
+        }
+    }
+    return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+    //initialize output file
+    if (logfile == NULL) {
+        libhtpFuzzInit();
+    }
+
+    htp_connp_t * connp = libhtpFuzzRun(Data, Size);
+    htp_conn_t * conn = htp_connp_get_connection(connp);
+
+    void* rstest = libhtprsFuzzRun(Data, Size);
+    void * rsconnp = libhtprsFuzzConnp(rstest);
+    if (connDiff(rsconnp, conn)) {
+        printf("results are different\n");
+    }
+    libhtprsFreeFuzzRun(rsconnp);
+
     htp_connp_destroy_all(connp);
-    // Destroy LibHTP configuration    
-    htp_config_destroy(cfg);
 
     return 0;
 }

--- a/test/test.c
+++ b/test/test.c
@@ -186,7 +186,7 @@ int test_next_chunk(test_t *test) {
             if (test->pos >= test->len) {
                 return 0;
             }
-            if (test->buf[test->pos] == '\n') test->pos++;
+            if (test->buf[test->pos-1] == '\r') test->pos++;
             if (test->pos >= test->len) {
                 return 0;
             }


### PR DESCRIPTION
- Some changes to the test framework to be more consistent
- Adds a fuzz target for differential fuzzing
- Fixes an actual bug about "empty lines"