### PR TITLE
header: do not stop on null byte

### DIFF
--- a/htp/htp_request_generic.c
+++ b/htp/htp_request_generic.c
@@ -227,8 +227,7 @@ htp_status_t htp_parse_request_header_generic(htp_connp_t *connp, htp_header_t *
     }
 
     // Look for the end of field-content.
-    value_end = value_start;
-    while ((value_end < len) && (data[value_end] != '\0')) value_end++;
+    value_end = len;
 
     // Ignore LWS after field-content.
     prev = value_end - 1;

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -154,7 +154,7 @@ TEST_F(ConnectionParsing, ApacheHeaderParsing) {
                 break;
             case 8:
                 ASSERT_EQ(0, bstr_cmp_c(h->name, "Header-With-NUL"));
-                ASSERT_EQ(0, bstr_cmp_c(h->value, "BEFORE"));
+                ASSERT_EQ(0, bstr_cmp_c_nocasenorzero(h->value, "BEFOREAFTER"));
                 break;
         }
 
@@ -1570,7 +1570,7 @@ TEST_F(ConnectionParsing, InvalidRequestHeader) {
 
     htp_header_t *h = (htp_header_t *) htp_table_get_c(tx->request_headers, "Header-With-NUL");
     ASSERT_TRUE(h != NULL);
-    ASSERT_EQ(0, bstr_cmp_c(h->value, "BEFORE"));
+    ASSERT_EQ(0, bstr_cmp_c_nocasenorzero(h->value, "BEFORE  AFTER"));
 }
 
 TEST_F(ConnectionParsing, TestGenericPersonality) {


### PR DESCRIPTION
Do not stop on request headers, as is already done
on response headers, and in the libhtp rust version

The differential fuzzing found the difference on test case 68-invalid-request-header.t