### PR TITLE
support HTTP Bearer authentication (fix #324)

### DIFF
--- a/htp/htp_core.h
+++ b/htp/htp_core.h
@@ -136,6 +136,9 @@ enum htp_auth_type_t {
     /** HTTP Digest authentication used. */
     HTP_AUTH_DIGEST = 3,
 
+    /** HTTP Digest authentication used. */
+    HTP_AUTH_BEARER = 4,
+
     /** Unrecognized authentication method. */
     HTP_AUTH_UNRECOGNIZED = 9
 };

--- a/htp/htp_parsers.c
+++ b/htp/htp_parsers.c
@@ -162,6 +162,24 @@ int htp_parse_authorization_basic(htp_connp_t *connp, htp_header_t *auth_header)
 }
 
 /**
+ * Parses Bearer Authorization request header.
+ *
+ * @param[in] connp
+ * @param[in] auth_header
+ */
+int htp_parse_authorization_bearer(htp_connp_t *connp, htp_header_t *auth_header) {
+    unsigned char *data = bstr_ptr(auth_header->value);
+    size_t len = bstr_len(auth_header->value);
+    size_t pos = 6;
+
+    // Ignore whitespace
+    while ((pos < len) && (isspace((int) data[pos]))) pos++;
+    if (pos == len) return HTP_DECLINED;
+
+    // There is nothing much else to check with Bearer auth so we just return
+    return HTP_OK;
+}
+/**
  * Parses Authorization request header.
  *
  * @param[in] connp
@@ -183,6 +201,10 @@ int htp_parse_authorization(htp_connp_t *connp) {
         // Digest authentication
         connp->in_tx->request_auth_type = HTP_AUTH_DIGEST;
         return htp_parse_authorization_digest(connp, auth_header);
+    } else if (bstr_begins_with_c_nocase(auth_header->value, "bearer")) {
+        // OAuth Bearer authentication
+        connp->in_tx->request_auth_type = HTP_AUTH_BEARER;
+        return htp_parse_authorization_bearer(connp, auth_header);
     } else {
         // Unrecognized authentication method
         connp->in_tx->request_auth_type = HTP_AUTH_UNRECOGNIZED;        

--- a/htp/htp_private.h
+++ b/htp/htp_private.h
@@ -186,6 +186,7 @@ int64_t htp_parse_positive_integer_whitespace(unsigned char *data, size_t len, i
 int htp_parse_status(bstr *status);
 int htp_parse_authorization_digest(htp_connp_t *connp, htp_header_t *auth_header);
 int htp_parse_authorization_basic(htp_connp_t *connp, htp_header_t *auth_header);
+int htp_parse_authorization_bearer(htp_connp_t *connp, htp_header_t *auth_header);
 
 void htp_print_log(FILE *stream, htp_log_t *log);
 

--- a/test/files/100-auth-bearer.t
+++ b/test/files/100-auth-bearer.t
@@ -1,0 +1,5 @@
+>>>
+GET / HTTP/1.1
+Host: www.example.com
+Authorization: Bearer mF_9.B5f-4.1JqM
+

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -1009,6 +1009,22 @@ TEST_F(ConnectionParsing, AuthDigest) {
     ASSERT_TRUE(tx->request_auth_password == NULL);
 }
 
+TEST_F(ConnectionParsing, AuthBearer) {
+    int rc = test_run(home, "100-auth-bearer.t", cfg, &connp);
+    ASSERT_GE(rc, 0);
+
+    htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
+    ASSERT_TRUE(tx != NULL);
+
+    ASSERT_EQ(HTP_REQUEST_COMPLETE, tx->request_progress);
+
+    ASSERT_EQ(HTP_AUTH_BEARER, tx->request_auth_type);
+
+    ASSERT_TRUE(tx->request_auth_username == NULL);
+
+    ASSERT_TRUE(tx->request_auth_password == NULL);
+}
+
 TEST_F(ConnectionParsing, Unknown_MethodOnly) {
     int rc = test_run(home, "42-unknown-method_only.t", cfg, &connp);
     ASSERT_GE(rc, 0);


### PR DESCRIPTION
This adds support for Bearer type authorization header. Incorporated suggestions by @catenacyber at https://github.com/OISF/libhtp/pull/325#pullrequestreview-620194346:

- defined `HTP_AUTH_BEARER` constant,
- added test file and `TEST_F(ConnectionParsing, AuthBearer)` using example from RFC6750.

Fixes #324.