### PR TITLE
htp: trim white space of invalid foloding for first header

### DIFF
--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -700,7 +700,14 @@ htp_status_t htp_connp_REQ_HEADERS(htp_connp_t *connp) {
                     }
 
                     // Keep the header data for parsing later.
-                    connp->in_header = bstr_dup_mem(data, len);
+                    size_t trim = 0;
+                    while(trim < len) {
+                        if (!htp_is_folding_char(data[trim])) {
+                            break;
+                        }
+                        trim++;
+                    }
+                    connp->in_header = bstr_dup_mem(data + trim, len - trim);
                     if (connp->in_header == NULL) return HTP_ERROR;
                 } else {
                     // Add to the existing header.                    

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -946,7 +946,14 @@ htp_status_t htp_connp_RES_HEADERS(htp_connp_t *connp) {
                     }
 
                     // Keep the header data for parsing later.
-                    connp->out_header = bstr_dup_mem(data, len);
+                    size_t trim = 0;
+                    while(trim < len) {
+                        if (!htp_is_folding_char(data[trim])) {
+                            break;
+                        }
+                        trim++;
+                    }
+                    connp->out_header = bstr_dup_mem(data + trim, len - trim);
                     if (connp->out_header == NULL) return HTP_ERROR;
                 } else {
                     size_t colon_pos = 0;

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -121,7 +121,7 @@ TEST_F(ConnectionParsing, ApacheHeaderParsing) {
 
         switch (count) {
             case 0:
-                ASSERT_EQ(0, bstr_cmp_c(h->name, " Invalid-Folding"));
+                ASSERT_EQ(0, bstr_cmp_c(h->name, "Invalid-Folding"));
                 ASSERT_EQ(0, bstr_cmp_c(h->value, "1"));
                 break;
             case 1:


### PR DESCRIPTION
as does the rust version