### PR TITLE
Compression lessfnptrs v2

### DIFF
--- a/htp/htp_decompressors.c
+++ b/htp/htp_decompressors.c
@@ -182,7 +182,7 @@ static void htp_gzip_decompressor_end(htp_decompressor_gzip_t *drec) {
  * @param[in] d
  * @return HTP_OK on success, HTP_ERROR or some other negative integer on failure.
  */
-static htp_status_t htp_gzip_decompressor_decompress(htp_decompressor_gzip_t *drec, htp_tx_data_t *d) {
+htp_status_t htp_gzip_decompressor_decompress(htp_decompressor_gzip_t *drec, htp_tx_data_t *d) {
     size_t consumed = 0;
     int rc = 0;
     htp_status_t callback_rc;
@@ -404,7 +404,7 @@ restart:
  *
  * @param[in] drec
  */
-static void htp_gzip_decompressor_destroy(htp_decompressor_gzip_t *drec) {
+void htp_gzip_decompressor_destroy(htp_decompressor_gzip_t *drec) {
     if (drec == NULL) return;
 
     htp_gzip_decompressor_end(drec);
@@ -424,8 +424,8 @@ htp_decompressor_t *htp_gzip_decompressor_create(htp_connp_t *connp, enum htp_co
     htp_decompressor_gzip_t *drec = calloc(1, sizeof (htp_decompressor_gzip_t));
     if (drec == NULL) return NULL;
 
-    drec->super.decompress = (int (*)(htp_decompressor_t *, htp_tx_data_t *))htp_gzip_decompressor_decompress;
-    drec->super.destroy = (void (*)(htp_decompressor_t *))htp_gzip_decompressor_destroy;
+    drec->super.decompress = NULL;
+    drec->super.destroy = NULL;
     drec->super.next = NULL;
 
     drec->buffer = malloc(GZIP_BUF_SIZE);

--- a/htp/htp_decompressors.h
+++ b/htp/htp_decompressors.h
@@ -55,8 +55,10 @@ typedef struct htp_decompressor_t htp_decompressor_t;
 #define DEFLATE_MAGIC_2         0x8b
 
 struct htp_decompressor_t {
+    // no longer used
     htp_status_t (*decompress)(htp_decompressor_t *, htp_tx_data_t *);
     htp_status_t (*callback)(htp_tx_data_t *);
+    // no longer used
     void (*destroy)(htp_decompressor_t *);
     struct htp_decompressor_t *next;
     struct timeval time_before;
@@ -81,6 +83,8 @@ struct htp_decompressor_gzip_t {
 };
 
 htp_decompressor_t *htp_gzip_decompressor_create(htp_connp_t *connp, enum htp_content_encoding_t format);
+htp_status_t htp_gzip_decompressor_decompress(htp_decompressor_gzip_t *drec, htp_tx_data_t *d);
+void htp_gzip_decompressor_destroy(htp_decompressor_gzip_t *drec);
 
 #ifdef __cplusplus
 }

--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -700,7 +700,14 @@ htp_status_t htp_connp_REQ_HEADERS(htp_connp_t *connp) {
                     }
 
                     // Keep the header data for parsing later.
-                    connp->in_header = bstr_dup_mem(data, len);
+                    size_t trim = 0;
+                    while(trim < len) {
+                        if (!htp_is_folding_char(data[trim])) {
+                            break;
+                        }
+                        trim++;
+                    }
+                    connp->in_header = bstr_dup_mem(data + trim, len - trim);
                     if (connp->in_header == NULL) return HTP_ERROR;
                 } else {
                     // Add to the existing header.                    

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -946,7 +946,14 @@ htp_status_t htp_connp_RES_HEADERS(htp_connp_t *connp) {
                     }
 
                     // Keep the header data for parsing later.
-                    connp->out_header = bstr_dup_mem(data, len);
+                    size_t trim = 0;
+                    while(trim < len) {
+                        if (!htp_is_folding_char(data[trim])) {
+                            break;
+                        }
+                        trim++;
+                    }
+                    connp->out_header = bstr_dup_mem(data + trim, len - trim);
                     if (connp->out_header == NULL) return HTP_ERROR;
                 } else {
                     size_t colon_pos = 0;

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -121,7 +121,7 @@ TEST_F(ConnectionParsing, ApacheHeaderParsing) {
 
         switch (count) {
             case 0:
-                ASSERT_EQ(0, bstr_cmp_c(h->name, " Invalid-Folding"));
+                ASSERT_EQ(0, bstr_cmp_c(h->name, "Invalid-Folding"));
                 ASSERT_EQ(0, bstr_cmp_c(h->value, "1"));
                 break;
             case 1:


### PR DESCRIPTION
decompression: use less function pointers as it is always the same function anyways

Replaces #357 with keeping the exported struct fields even if we no longer use them