### PR TITLE
Compression lessfnptrs v3

### DIFF
--- a/htp/htp_decompressors.c
+++ b/htp/htp_decompressors.c
@@ -182,10 +182,11 @@ static void htp_gzip_decompressor_end(htp_decompressor_gzip_t *drec) {
  * @param[in] d
  * @return HTP_OK on success, HTP_ERROR or some other negative integer on failure.
  */
-static htp_status_t htp_gzip_decompressor_decompress(htp_decompressor_gzip_t *drec, htp_tx_data_t *d) {
+htp_status_t htp_gzip_decompressor_decompress(htp_decompressor_t *drec1, htp_tx_data_t *d) {
     size_t consumed = 0;
     int rc = 0;
     htp_status_t callback_rc;
+    htp_decompressor_gzip_t *drec = (htp_decompressor_gzip_t*) drec1;
 
     // Pass-through the NULL chunk, which indicates the end of the stream.
 
@@ -404,7 +405,8 @@ restart:
  *
  * @param[in] drec
  */
-static void htp_gzip_decompressor_destroy(htp_decompressor_gzip_t *drec) {
+void htp_gzip_decompressor_destroy(htp_decompressor_t *drec1) {
+    htp_decompressor_gzip_t *drec = (htp_decompressor_gzip_t*) drec1;
     if (drec == NULL) return;
 
     htp_gzip_decompressor_end(drec);
@@ -424,8 +426,8 @@ htp_decompressor_t *htp_gzip_decompressor_create(htp_connp_t *connp, enum htp_co
     htp_decompressor_gzip_t *drec = calloc(1, sizeof (htp_decompressor_gzip_t));
     if (drec == NULL) return NULL;
 
-    drec->super.decompress = (int (*)(htp_decompressor_t *, htp_tx_data_t *))htp_gzip_decompressor_decompress;
-    drec->super.destroy = (void (*)(htp_decompressor_t *))htp_gzip_decompressor_destroy;
+    drec->super.decompress = NULL;
+    drec->super.destroy = NULL;
     drec->super.next = NULL;
 
     drec->buffer = malloc(GZIP_BUF_SIZE);

--- a/htp/htp_decompressors.h
+++ b/htp/htp_decompressors.h
@@ -55,8 +55,10 @@ typedef struct htp_decompressor_t htp_decompressor_t;
 #define DEFLATE_MAGIC_2         0x8b
 
 struct htp_decompressor_t {
+    // no longer used
     htp_status_t (*decompress)(htp_decompressor_t *, htp_tx_data_t *);
     htp_status_t (*callback)(htp_tx_data_t *);
+    // no longer used
     void (*destroy)(htp_decompressor_t *);
     struct htp_decompressor_t *next;
     struct timeval time_before;
@@ -81,6 +83,8 @@ struct htp_decompressor_gzip_t {
 };
 
 htp_decompressor_t *htp_gzip_decompressor_create(htp_connp_t *connp, enum htp_content_encoding_t format);
+htp_status_t htp_gzip_decompressor_decompress(htp_decompressor_t *drec, htp_tx_data_t *d);
+void htp_gzip_decompressor_destroy(htp_decompressor_t *drec);
 
 #ifdef __cplusplus
 }

--- a/test/test_gunzip.cpp
+++ b/test/test_gunzip.cpp
@@ -46,6 +46,7 @@
 
 #include <gtest/gtest.h>
 #include <htp/htp_private.h>
+#include <htp/htp_decompressors.h>
 
 #ifndef O_BINARY
 #define O_BINARY 0
@@ -103,7 +104,7 @@ protected:
 
         // Decompress
 
-        htp_status_t rc = decompressor->decompress(decompressor, &d);
+        htp_status_t rc = htp_gzip_decompressor_decompress(decompressor, &d);
 
         free((void *)d.data);
 
@@ -134,7 +135,7 @@ protected:
     virtual void TearDown() {
         bstr_free(output);
         bstr_free(o_boxing_wizards);
-        decompressor->destroy(decompressor);
+        htp_gzip_decompressor_destroy(decompressor);
         htp_connp_destroy_all(connp);
         htp_config_destroy(cfg);
     }


### PR DESCRIPTION
decompression: use less function pointers as it is always the same function anyways

Replaces #357 with keeping the exported struct fields even if we no longer use them
Replaces #359 with changing unit test use of API