### PR TITLE
decompression: fix coverity warning

### DIFF
--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -612,6 +612,7 @@ htp_status_t htp_tx_req_process_body_data_ex(htp_tx_t *tx, const void *data, siz
     d.tx = tx;
     d.data = (unsigned char *) data;
     d.len = len;
+    d.is_last = (data == NULL && len == 0);
 
     switch(tx->request_content_encoding) {
         case HTP_COMPRESSION_UNKNOWN:

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -2089,6 +2089,8 @@ TEST_F(ConnectionParsing, Expect100) {
     ASSERT_EQ(HTP_RESPONSE_COMPLETE, tx->response_progress);
 }
 
+// emplace_back needs at least C++ 11
+#if __cplusplus > 199711L
 struct ResponseBodyDataCallback {
     std::vector<std::string> data;
 };
@@ -2128,3 +2130,4 @@ TEST_F(ConnectionParsing, ResponseBodyData) {
 
     delete user_data;
 }
+#endif


### PR DESCRIPTION
about uninitialized field d.is_last