### PR TITLE
fuzz_diff: Free the rust test object.

### DIFF
--- a/test/fuzz/fuzz_diff.c
+++ b/test/fuzz/fuzz_diff.c
@@ -431,7 +431,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     if (connDiff(rsconnp, conn)) {
         printf("results are different\n");
     }
-    libhtprsFreeFuzzRun(rsconnp);
+    libhtprsFreeFuzzRun(rstest);
 
     htp_connp_destroy_all(connp);
 


### PR DESCRIPTION
When running the differential fuzzing I got segfaults because `libhtprsFreeFuzzRun()` expects a test structure, but is being passed a connp structure. 