### PR TITLE
response: headers wait to know if folding comes

### DIFF
--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -926,7 +926,8 @@ htp_status_t htp_connp_RES_HEADERS(htp_connp_t *connp) {
 
                 OUT_PEEK_NEXT(connp);
 
-                if (htp_is_folding_char(connp->out_next_byte) == 0) {
+                if (connp->out_next_byte != -1 &&
+                    htp_is_folding_char(connp->out_next_byte) == 0) {
                     // Because we know this header is not folded, we can process the buffer straight away.
                     if (connp->cfg->process_response_header(connp, data, len) != HTP_OK) return HTP_ERROR;
                 } else {


### PR DESCRIPTION
Previously, we fell back on HTTP/0.9 if there was a missing protocol except if the following line cintained a colon.

This makes libhtp stricter to consider a transaction as 0.9 by only accepting if we have spaces after the request line

Meant to fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=54982&q=label%3AProj-libhtp