### PR TITLE
response: only trim spaces at headers names end

### DIFF
--- a/htp/htp_response_generic.c
+++ b/htp/htp_response_generic.c
@@ -173,7 +173,7 @@ htp_status_t htp_parse_response_header_generic(htp_connp_t *connp, htp_header_t 
 
         // Ignore unprintable after field-name.
         prev = name_end;
-        while ((prev > name_start) && (data[prev - 1] <= 0x20)) {
+        while ((prev > name_start) && htp_is_space(data[prev - 1])) {
             prev--;
             name_end--;
 


### PR DESCRIPTION
https://redmine.openinfosecfoundation.org/issues/5971

Kind of as is done for requests
Ans as is done by libhtp-rs with `trim`

Here is the report for https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=54982 unminimized test case

```
c=: ptr 0x603000000568 offset 0 len 4
0lx  44 61 74 65                                       |Date|


rust=: ptr 0x6020000007f0 offset 0 len 12
0lx  44 61 74 65 11 00 00 00  00 00 00 00              |Date........|

Assertion failure: Bstr header-name lengths are different 12 vs 4
```

Still need to trim the real spaces to have http-evader happy