### PR TITLE
src: fix -Wshorten-64-to-32 warnings

### DIFF
--- a/htp/bstr.c
+++ b/htp/bstr.c
@@ -198,7 +198,7 @@ int bstr_chr(const bstr *b, int c) {
     size_t i = 0;
     while (i < len) {
         if (data[i] == c) {
-            return i;
+            return (int) i;
         }
 
         i++;
@@ -322,7 +322,7 @@ int bstr_rchr(const bstr *b, int c) {
     size_t i = len;
     while (i > 0) {
         if (data[i - 1] == c) {
-            return i - 1;
+            return (int) (i - 1);
         }
 
         i--;
@@ -506,7 +506,7 @@ int bstr_util_mem_index_of_mem(const void *_data1, size_t len1, const void *_dat
         }
 
         if (j == len2) {
-            return i;
+            return (int) i;
         }
     }
 
@@ -529,7 +529,7 @@ int bstr_util_mem_index_of_mem_nocase(const void *_data1, size_t len1, const voi
         }
 
         if (j == len2) {
-            return i;
+            return (int) i;
         }
     }
 
@@ -560,7 +560,7 @@ int bstr_util_mem_index_of_mem_nocasenorzero(const void *_data1, size_t len1, co
         }
 
         if (j == len2) {
-            return i;
+            return (int) i;
         }
     }
 

--- a/htp/htp_config.c
+++ b/htp/htp_config.c
@@ -528,7 +528,7 @@ void htp_config_set_compression_bomb_limit(htp_cfg_t *cfg, size_t bomblimit) {
     if (bomblimit > INT32_MAX) {
         cfg->compression_bomb_limit = INT32_MAX;
     } else {
-        cfg->compression_bomb_limit = bomblimit;
+        cfg->compression_bomb_limit = (int32_t) bomblimit;
     }
 }
 
@@ -538,7 +538,7 @@ void htp_config_set_compression_time_limit(htp_cfg_t *cfg, size_t useclimit) {
     if (useclimit >= 1000000) {
         cfg->compression_time_limit = 1000000;
     } else {
-        cfg->compression_time_limit = useclimit;
+        cfg->compression_time_limit = (int32_t) useclimit;
     }
 }
 

--- a/htp/htp_decompressors.c
+++ b/htp/htp_decompressors.c
@@ -232,12 +232,12 @@ htp_status_t htp_gzip_decompressor_decompress(htp_decompressor_t *drec1, htp_tx_
     }
 
 restart:
-    if (consumed > d->len) {
+    if (consumed > d->len || d->len > UINT32_MAX ) {
         htp_log(d->tx->connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0, "GZip decompressor: consumed > d->len");
         return HTP_ERROR;
     }
     drec->stream.next_in = (unsigned char *) (d->data + consumed);
-    drec->stream.avail_in = d->len - consumed;
+    drec->stream.avail_in = (uint32_t) (d->len - consumed);
 
     while (drec->stream.avail_in != 0) {
         // If there's no more data left in the
@@ -275,7 +275,7 @@ restart:
                 }
                 memcpy(drec->header + drec->header_len, drec->stream.next_in, consumed);
                 drec->stream.next_in = (unsigned char *) (d->data + consumed);
-                drec->stream.avail_in = d->len - consumed;
+                drec->stream.avail_in = (uint32_t) (d->len - consumed);
                 drec->header_len += consumed;
             }
             if (drec->header_len == LZMA_PROPS_SIZE + 8) {

--- a/htp/htp_transcoder.c
+++ b/htp/htp_transcoder.c
@@ -74,7 +74,7 @@ int htp_transcode_params(htp_connp_t *connp, htp_table_t **params, int destroy_o
     // Convert the parameters, one by one
     bstr *name = NULL;
     bstr *value = NULL;    
-    for (int i = 0, n = htp_table_size(input_params); i < n; i++) {
+    for (size_t i = 0, n = htp_table_size(input_params); i < n; i++) {
         value = htp_table_get_index(input_params, i, &name);
         
         bstr *new_name = NULL, *new_value = NULL;        
@@ -85,7 +85,7 @@ int htp_transcode_params(htp_connp_t *connp, htp_table_t **params, int destroy_o
             iconv_close(cd);
 
             bstr *b = NULL;
-            for (int j = 0, k = htp_table_size(output_params); j < k; j++) {
+            for (size_t j = 0, k = htp_table_size(output_params); j < k; j++) {
                 b = htp_table_get_index(output_params, j, NULL);
                 bstr_free(b);
             }
@@ -101,7 +101,7 @@ int htp_transcode_params(htp_connp_t *connp, htp_table_t **params, int destroy_o
             iconv_close(cd);
 
             bstr *b = NULL;
-            for (int j = 0, k = htp_table_size(output_params); j < k; j++) {
+            for (size_t j = 0, k = htp_table_size(output_params); j < k; j++) {
                 b = htp_table_get_index(output_params, j, NULL);
                 bstr_free(b);
             }
@@ -120,7 +120,7 @@ int htp_transcode_params(htp_connp_t *connp, htp_table_t **params, int destroy_o
     // Destroy the old parameter table if necessary
     if (destroy_old) {
         bstr *b = NULL;
-        for (int i = 0, n = htp_table_size(input_params); i < n; i++) {
+        for (size_t i = 0, n = htp_table_size(input_params); i < n; i++) {
             b = htp_table_get_index(input_params, i, NULL);
             bstr_free(b);
         }      

--- a/htp/htp_util.c
+++ b/htp/htp_util.c
@@ -536,7 +536,7 @@ static htp_status_t htp_parse_port(unsigned char *data, size_t len, int *port, i
         *invalid = 1;
     } else if ((port_parsed > 0) && (port_parsed < 65536)) {
         // Valid port number.
-        *port = port_parsed;
+        *port = (int) port_parsed;
     } else {
         // Port number out of range.
         *port = -1;


### PR DESCRIPTION
https://redmine.openinfosecfoundation.org/issues/6186

https://github.com/OISF/libhtp/pull/396 with more fixes for more architectures (size_t != int)