### PR TITLE
http0.9: process headers if there are non-space characters

### DIFF
--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -744,21 +744,15 @@ htp_status_t htp_connp_REQ_PROTOCOL(htp_connp_t *connp) {
     } else {
         // Let's check if the protocol was simply missing
         int64_t pos = connp->in_current_read_offset;
-        int afterspaces = 0;
         // Probe if data looks like a header line
         while (pos < connp->in_current_len) {
-            if (connp->in_current_data[pos] == ':') {
+            if (!htp_is_space(connp->in_current_data[pos])) {
                 htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Request line: missing protocol");
                 connp->in_tx->is_protocol_0_9 = 0;
                 // Switch to request header parsing.
                 connp->in_state = htp_connp_REQ_HEADERS;
                 connp->in_tx->request_progress = HTP_REQUEST_HEADERS;
                 return HTP_OK;
-            } else if (htp_is_lws(connp->in_current_data[pos])) {
-                // Allows spaces after header name
-                afterspaces = 1;
-            } else if (htp_is_space(connp->in_current_data[pos]) || afterspaces == 1) {
-                break;
             }
             pos++;
         }


### PR DESCRIPTION
Previously, we fell back on HTTP/0.9 if there was a missing protocol except if the following line contained a colon.

We make libhtp simpler by only switching to HTTP/0.9 if we have only spaces afterwards