### PR TITLE
http0.9: process headers if there are non-space characters

### DIFF
--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -744,21 +744,15 @@ htp_status_t htp_connp_REQ_PROTOCOL(htp_connp_t *connp) {
     } else {
         // Let's check if the protocol was simply missing
         int64_t pos = connp->in_current_read_offset;
-        int afterspaces = 0;
         // Probe if data looks like a header line
         while (pos < connp->in_current_len) {
-            if (connp->in_current_data[pos] == ':') {
+            if (!htp_is_space(connp->in_current_data[pos])) {
                 htp_log(connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "Request line: missing protocol");
                 connp->in_tx->is_protocol_0_9 = 0;
                 // Switch to request header parsing.
                 connp->in_state = htp_connp_REQ_HEADERS;
                 connp->in_tx->request_progress = HTP_REQUEST_HEADERS;
                 return HTP_OK;
-            } else if (htp_is_lws(connp->in_current_data[pos])) {
-                // Allows spaces after header name
-                afterspaces = 1;
-            } else if (htp_is_space(connp->in_current_data[pos]) || afterspaces == 1) {
-                break;
             }
             pos++;
         }

--- a/test/test_main.cpp
+++ b/test/test_main.cpp
@@ -558,7 +558,6 @@ TEST_F(ConnectionParsing, Http_0_9_Multiple) {
     ASSERT_GE(rc, 0);
 
     ASSERT_EQ(1, htp_list_size(connp->conn->transactions));
-    ASSERT_TRUE(connp->conn->flags & HTP_CONN_HTTP_0_9_EXTRA);
 
     htp_tx_t *tx = (htp_tx_t *) htp_list_get(connp->conn->transactions, 0);
     ASSERT_TRUE(tx != NULL);


### PR DESCRIPTION
Previously, we fell back on HTTP/0.9 if there was a missing protocol except if the following line contained a colon.

We make libhtp simpler by only switching to HTTP/0.9 if we have only spaces afterwards

#404 with passing tests

https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=54982&q=label%3AProj-libhtp&can=2