### PR TITLE
uri: normalization removes trailing spaces

### DIFF
--- a/htp/htp_util.c
+++ b/htp/htp_util.c
@@ -732,6 +732,13 @@ int htp_parse_uri(bstr *input, htp_uri_t **uri) {
 
     unsigned char *data = bstr_ptr(input);
     size_t len = bstr_len(input);
+    // remove trailing spaces
+    while (len > 0) {
+        if (data[len-1] != ' ') {
+            break;
+        }
+        len--;
+    }
     size_t start, pos;
 
     if (len == 0) {


### PR DESCRIPTION
[Ticket: #2881](https://redmine.openinfosecfoundation.org/issues/2881

see also https://github.com/OISF/suricata/pull/9501