### PR TITLE
Http1 removetx 5921 v11

### DIFF
--- a/htp/htp_connection.c
+++ b/htp/htp_connection.c
@@ -148,10 +148,16 @@ htp_status_t htp_conn_open(htp_conn_t *conn, const char *client_addr, int client
 htp_status_t htp_conn_remove_tx(htp_conn_t *conn, const htp_tx_t *tx) {
     if ((tx == NULL) || (conn == NULL)) return HTP_ERROR;
     if (conn->transactions == NULL) return HTP_ERROR;
-    for (size_t i = 0, n = htp_list_size(conn->transactions); i < n; i++) {
-        htp_tx_t *tx2 = htp_list_get(conn->transactions, i);
-        if (tx2 == tx) {
-            return htp_list_replace(conn->transactions, i, NULL);
+    size_t n = htp_list_size(conn->transactions);
+    if (n > 0) {
+        htp_tx_t *tx2 = htp_list_get(conn->transactions, n - 1);
+        if (tx2 != NULL) {
+            if (tx == tx2) {
+                // directly pop, no need to keep a NULL at the end
+                htp_list_array_pop(conn->transactions);
+                return HTP_OK;
+            } // else
+            return htp_list_replace(conn->transactions, n - 1 + tx->index - tx2->index, NULL);
         }
     }
     return HTP_DECLINED;

--- a/htp/htp_connection.c
+++ b/htp/htp_connection.c
@@ -81,6 +81,9 @@ void htp_conn_destroy(htp_conn_t *conn) {
         for (size_t i = 0, n = htp_list_size(conn->transactions); i < n; i++) {
             htp_tx_t *tx = htp_list_get(conn->transactions, i);
             if (tx != NULL) {
+                // nullify conn so as not to call htp_conn_remove_tx
+                // since we remove all txs
+                tx->conn = NULL;
                 htp_tx_destroy_incomplete(tx);
             }
         }

--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -61,7 +61,13 @@ htp_tx_t *htp_tx_create(htp_connp_t *connp) {
 
     tx->connp = connp;
     tx->conn = connp->conn;
-    tx->index = htp_list_size(tx->conn->transactions);
+    tx->index = 0;
+    if (htp_list_size(tx->conn->transactions) > 0) {
+        htp_tx_t *txl = htp_list_get(tx->conn->transactions, htp_list_size(tx->conn->transactions) - 1);
+        if (txl != NULL) {
+            tx->index = txl->index + 1;
+        }
+    }
     tx->cfg = connp->cfg;
     tx->is_config_shared = HTP_CONFIG_SHARED;
 


### PR DESCRIPTION
#416 with resistance to having the last (but not first) transaction being freed : popping it, instead of replacing it by NULL, so that we can still use its index