### PR TITLE
decompressor: only take erroneous data on first try

### DIFF
--- a/htp/htp_decompressors.c
+++ b/htp/htp_decompressors.c
@@ -317,7 +317,7 @@ restart:
             return HTP_ERROR;
         }
         if (GZIP_BUF_SIZE > drec->stream.avail_out) {
-            if (rc == Z_DATA_ERROR) {
+            if (rc == Z_DATA_ERROR && drec->restart == 0) {
                 // There is data even if there is an error
                 // So use this data and log a warning
                 htp_log(d->tx->connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "GZip decompressor: inflate failed with %d", rc);


### PR DESCRIPTION
https://redmine.openinfosecfoundation.org/issues/6959

Makes https://github.com/OISF/suricata-verify/pull/1773 pass