### PR TITLE
request: trim headers values also when there is no name

### DIFF
--- a/htp/htp_request_generic.c
+++ b/htp/htp_request_generic.c
@@ -172,7 +172,12 @@ htp_status_t htp_parse_request_header_generic(htp_connp_t *connp, htp_header_t *
         h->name = bstr_dup_c("");
         if (h->name == NULL) return HTP_ERROR;
 
-        h->value = bstr_dup_mem(data, len);
+        // Ignore LWS after field-content.
+        value_end = len - 1;
+        while ((value_end > 0) && (htp_is_lws(data[value_end]))) {
+            value_end--;
+        }
+        h->value = bstr_dup_mem(data, value_end + 1);
         if (h->value == NULL) {
             bstr_free(h->name);
             return HTP_ERROR;

--- a/test/fuzz/fuzz_diff.c
+++ b/test/fuzz/fuzz_diff.c
@@ -350,7 +350,7 @@ static int txDiff(void* rstx, htp_tx_t * ctx) {
         htp_header_t *h = (htp_header_t *) htp_table_get_index(ctx->request_headers, i, NULL);
         void *rsh = htp_tx_request_header_index(rstx, (size_t) i);
         if (bstrDiff(htp_header_name(rsh), h->name, "header-name")) {
-            printf("request header %d is different\n", i);
+            printf("request header name %d is different\n", i);
             fflush(stdout);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
             abort();
@@ -358,7 +358,7 @@ static int txDiff(void* rstx, htp_tx_t * ctx) {
             return 1;
         }
         if (bstrDiff(htp_header_value(rsh), h->value, "header-value")) {
-            printf("request header %d is different\n", i);
+            printf("request header value %d is different\n", i);
             fflush(stdout);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
             abort();
@@ -382,7 +382,7 @@ static int txDiff(void* rstx, htp_tx_t * ctx) {
         htp_header_t *h = (htp_header_t *) htp_table_get_index(ctx->response_headers, i, NULL);
         void *rsh = htp_tx_response_header_index(rstx, (size_t) i);
         if (bstrDiff(htp_header_name(rsh), h->name, "header-name")) {
-            printf("response header %d is different\n", i);
+            printf("response header name %d is different\n", i);
             fflush(stdout);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
             abort();
@@ -390,7 +390,7 @@ static int txDiff(void* rstx, htp_tx_t * ctx) {
             return 1;
         }
         if (bstrDiff(htp_header_value(rsh), h->value, "header-value")) {
-            printf("response header %d is different\n", i);
+            printf("response header value %d is different\n", i);
             fflush(stdout);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
             abort();

--- a/test/fuzz/fuzz_diff.c
+++ b/test/fuzz/fuzz_diff.c
@@ -339,6 +339,7 @@ static int txDiff(void* rstx, htp_tx_t * ctx) {
     uint32_t rsnbh = htp_tx_request_headers_size(rstx);
     if (rsnbh != nbhc) {
         printf("Assertion failure: got nbheaders c=%d versus rust=%d\n", nbhc, rsnbh);
+        fflush(stdout);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         abort();
 #endif
@@ -350,6 +351,7 @@ static int txDiff(void* rstx, htp_tx_t * ctx) {
         void *rsh = htp_tx_request_header_index(rstx, (size_t) i);
         if (bstrDiff(htp_header_name(rsh), h->name, "header-name")) {
             printf("request header %d is different\n", i);
+            fflush(stdout);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
             abort();
 #endif
@@ -357,6 +359,7 @@ static int txDiff(void* rstx, htp_tx_t * ctx) {
         }
         if (bstrDiff(htp_header_value(rsh), h->value, "header-value")) {
             printf("request header %d is different\n", i);
+            fflush(stdout);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
             abort();
 #endif
@@ -368,6 +371,7 @@ static int txDiff(void* rstx, htp_tx_t * ctx) {
     rsnbh = htp_tx_response_headers_size(rstx);
     if (rsnbh != nbhc) {
         printf("Assertion failure: got nbheaders c=%d versus rust=%d\n", nbhc, rsnbh);
+        fflush(stdout);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         abort();
 #endif
@@ -379,6 +383,7 @@ static int txDiff(void* rstx, htp_tx_t * ctx) {
         void *rsh = htp_tx_response_header_index(rstx, (size_t) i);
         if (bstrDiff(htp_header_name(rsh), h->name, "header-name")) {
             printf("response header %d is different\n", i);
+            fflush(stdout);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
             abort();
 #endif
@@ -386,6 +391,7 @@ static int txDiff(void* rstx, htp_tx_t * ctx) {
         }
         if (bstrDiff(htp_header_value(rsh), h->value, "header-value")) {
             printf("response header %d is different\n", i);
+            fflush(stdout);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
             abort();
 #endif
@@ -401,6 +407,7 @@ static int connDiff(void* rsconnp, htp_conn_t * conn) {
     uint32_t c = htp_list_size(conn->transactions);
     if (rs != c) {
         printf("Assertion failure: got nbtx c=%d versus rust=%d\n", c, rs);
+        fflush(stdout);
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         abort();
 #endif


### PR DESCRIPTION
As is done by libhtp-rs

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=59750&q=label%3AProj-libhtp