### PR TITLE
scan-build: work around optin.performance.Padding

### DIFF
--- a/htp/htp.h
+++ b/htp/htp.h
@@ -221,6 +221,8 @@ struct htp_tx_t {
      */
     int is_config_shared;
 
+    SCAN_BUILD_X64_PADDING(int pad0;)
+
     /** The user data associated with this transaction. */
     void *user_data;
     
@@ -230,6 +232,8 @@ struct htp_tx_t {
     /** Contains a count of how many empty lines were skipped before the request line. */
     unsigned int request_ignored_lines;
 
+    SCAN_BUILD_X64_PADDING(int pad1;)
+
     /** The first line of this request. */
     bstr *request_line;      
 
@@ -238,6 +242,8 @@ struct htp_tx_t {
 
     /** Request method, as number. Available only if we were able to recognize the request method. */
     enum htp_method_t request_method_number;
+
+    SCAN_BUILD_X64_PADDING(int pad2;)
 
     /**
      * Request URI, raw, as given to us on the request line. This field can take different forms,
@@ -421,6 +427,8 @@ struct htp_tx_t {
      */
     int response_protocol_number;
 
+    SCAN_BUILD_X64_PADDING(int pad3;)
+
     /**
      * Response status code, as text. Starts as NULL and can remain NULL on
      * an invalid response that does not specify status code.
@@ -444,6 +452,8 @@ struct htp_tx_t {
 
     /** Have we seen the server respond with a 100 response? */
     int seen_100continue;      
+
+    SCAN_BUILD_X64_PADDING(int pad4;)
 
     /** Parsed response headers. Contains instances of htp_header_t. */
     htp_table_t *response_headers;   
@@ -512,6 +522,8 @@ struct htp_tx_t {
      */
     enum htp_content_encoding_t response_content_encoding_processing;
     
+    SCAN_BUILD_X64_PADDING(int pad5;)
+
     /**
      * This field will contain the response content type when that information
      * is available in response headers. The contents of the field will be converted

--- a/htp/htp_core.h
+++ b/htp/htp_core.h
@@ -43,6 +43,57 @@
 extern "C" {
 #endif
 
+/* Define SCAN_BUILD_X64_PADDING to add padding to structs for
+ * when clang scan-build is used with the optin.performance.Padding
+ * checker. */
+#if defined(__clang_analyzer__)
+/** FreeBSD does not define __WORDSIZE, but it uses __LONG_BIT */
+#ifndef __WORDSIZE
+    #ifdef __LONG_BIT
+        #define __WORDSIZE __LONG_BIT
+    #else
+        #ifdef LONG_BIT
+            #define __WORDSIZE LONG_BIT
+        #endif
+    #endif
+#endif
+
+/** Windows does not define __WORDSIZE, but it uses __X86__ */
+#ifndef __WORDSIZE
+    #if defined(__X86__) || defined(_X86_) || defined(_M_IX86)
+        #define __WORDSIZE 32
+    #else
+        #if defined(__X86_64__) || defined(_X86_64_) || \
+            defined(__x86_64)   || defined(__x86_64__) || \
+            defined(__amd64)    || defined(__amd64__)
+            #define __WORDSIZE 64
+        #endif
+    #endif
+#endif
+
+/** if not succesful yet try the data models */
+#ifndef __WORDSIZE
+    #if defined(_ILP32) || defined(__ILP32__)
+        #define __WORDSIZE 32
+    #endif
+    #if defined(_LP64) || defined(__LP64__)
+        #define __WORDSIZE 64
+    #endif
+#endif
+
+#ifndef __WORDSIZE
+    #define __WORDSIZE 64
+#endif
+
+#if __WORDSIZE==64
+#define SCAN_BUILD_X64_PADDING(x)   x
+#else
+#define SCAN_BUILD_X64_PADDING(_x)
+#endif
+#else /* else __clang_analyzer__ */
+#define SCAN_BUILD_X64_PADDING(_x)
+#endif /* end __clang_analyzer__ */
+
 typedef int htp_status_t;
 
 typedef struct htp_cfg_t htp_cfg_t;


### PR DESCRIPTION
Since the layout has to be preserved, padding is added.

This is to help the Suricata scan-build CI jobs currently showing lots of
```
2024-12-17T21:44:21.4770026Z ./../libhtp/htp/htp.h:208:8: warning: Excessive padding in 'struct htp_tx_t' (32 padding bytes, where 0 is optimal). Optimal fields order: connp, conn, cfg, user_data, request_line, request_method, request_uri, request_protocol, parsed_uri, parsed_uri_raw, request_message_len, request_entity_len, request_headers, request_content_type, request_content_length, hook_request_body_data, hook_response_body_data, request_urlenp_query, request_urlenp_body, request_mpartp, request_params, request_cookies, request_auth_username, request_auth_password, request_hostname, response_line, response_protocol, response_status, response_message, response_headers, response_message_len, response_entity_len, response_content_length, response_content_type, flags, index, is_config_shared, request_ignored_lines, request_method_number, request_protocol_number, is_protocol_0_9, request_transfer_coding, request_content_encoding, request_auth_type, request_port_number, response_ignored_lines, response_protocol_number, response_status_number, response_status_expected_number, seen_100continue, response_transfer_coding, response_content_encoding, response_content_encoding_processing, request_progress, response_progress, req_header_repetitions, res_header_repetitions, consider reordering the fields or adding explicit padding members [optin.performance.Padding]
2024-12-17T21:44:21.4774220Z   208 | struct htp_tx_t {
2024-12-17T21:44:21.4774415Z       | ~~~~~~~^~~~~~~~~~
2024-12-17T21:44:21.4774688Z   209 |     /** The connection parser associated with this transaction. */
2024-12-17T21:44:21.4775028Z       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-12-17T21:44:21.4775288Z   210 |     htp_connp_t *connp;
2024-12-17T21:44:21.4775495Z       |     ~~~~~~~~~~~~~~~~~~~
2024-12-17T21:44:21.4775812Z   211 | 
2024-12-17T21:44:21.4776177Z   212 |     /** The connection to which this transaction belongs. */
2024-12-17T21:44:21.4776708Z       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-12-17T21:44:21.4777117Z   213 |     htp_conn_t *conn;   
2024-12-17T21:44:21.4777468Z       |     ~~~~~~~~~~~~~~~~~
2024-12-17T21:44:21.4777763Z   214 | 
2024-12-17T21:44:21.4778203Z   215 |     /** The configuration structure associated with this transaction. */
2024-12-17T21:44:21.4778783Z       |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-12-17T21:44:21.4779051Z   216 |     htp_cfg_t *cfg;
2024-12-17T21:44:21.4779246Z       |     ~~~~~~~~~~~~~~~
2024-12-17T21:44:21.4779627Z   217 | 
2024-12-17T21:44:21.4779825Z   218 |     /**
2024-12-17T21:44:21.4780094Z       |     ~~~
2024-12-17T21:44:21.4780625Z   219 |      * Is the configuration structure shared with other transactions or connections? If
2024-12-17T21:44:21.4781060Z       |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-12-17T21:44:21.4781456Z   220 |      * this field is set to HTP_CONFIG_PRIVATE, the transaction owns the configuration.
2024-12-17T21:44:21.4781965Z       |      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2024-12-17T21:44:21.4782224Z   221 |      */
2024-12-17T21:44:21.4782384Z       |      ~~
2024-12-17T21:44:21.4782562Z   222 |     int is_config_shared;
2024-12-17T21:44:21.4782779Z       |     ~~~~~~~~~~~~~~~~~~~~~
2024-12-17T21:44:21.4782975Z   223 | 
```