### PR TITLE
response: handle properly gaps in chunked data

### DIFF
--- a/htp/htp_decompressors.c
+++ b/htp/htp_decompressors.c
@@ -316,15 +316,8 @@ restart:
             // no initialization means previous error on stream
             return HTP_ERROR;
         }
-        if (GZIP_BUF_SIZE > drec->stream.avail_out) {
-            if (rc == Z_DATA_ERROR && drec->restart == 0) {
-                // There is data even if there is an error
-                // So use this data and log a warning
-                htp_log(d->tx->connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "GZip decompressor: inflate failed with %d", rc);
-                rc = Z_STREAM_END;
-            }
-        }
-        if (rc == Z_STREAM_END) {
+        int error_after_data = (rc == Z_DATA_ERROR && drec->restart == 0 && GZIP_BUF_SIZE > drec->stream.avail_out);
+        if (rc == Z_STREAM_END || error_after_data) {
             // How many bytes do we have?
             size_t len = GZIP_BUF_SIZE - drec->stream.avail_out;
 
@@ -351,6 +344,12 @@ restart:
             drec->stream.next_out = drec->buffer;
             // TODO Handle trailer.
 
+            if (error_after_data) {
+                // There is data even if there is an error
+                // So use this data and log a warning
+                htp_log(d->tx->connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "GZip decompressor: inflate failed with %d", rc);
+                return HTP_ERROR;
+            }
             return HTP_OK;
         }
         else if (rc != Z_OK) {

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -1349,6 +1349,7 @@ int htp_connp_res_data(htp_connp_t *connp, const htp_time_t *timestamp, const vo
         //handle gap
         if (data == NULL && len > 0) {
             if (connp->out_state == htp_connp_RES_BODY_IDENTITY_CL_KNOWN ||
+                connp->out_state == htp_connp_RES_BODY_CHUNKED_DATA ||
                 connp->out_state == htp_connp_RES_BODY_IDENTITY_STREAM_CLOSE) {
                 rc = connp->out_state(connp);
             } else if (connp->out_state == htp_connp_RES_FINALIZE) {


### PR DESCRIPTION
And decompressors: do not take data after end

Trying to get libhtp.c and libhtp.rs to behave the same

Will need a QA rebaseline