### PR TITLE
response: handle properly gaps in chunked data

### DIFF
--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -1349,6 +1349,7 @@ int htp_connp_res_data(htp_connp_t *connp, const htp_time_t *timestamp, const vo
         //handle gap
         if (data == NULL && len > 0) {
             if (connp->out_state == htp_connp_RES_BODY_IDENTITY_CL_KNOWN ||
+                connp->out_state == htp_connp_RES_BODY_CHUNKED_DATA ||
                 connp->out_state == htp_connp_RES_BODY_IDENTITY_STREAM_CLOSE) {
                 rc = connp->out_state(connp);
             } else if (connp->out_state == htp_connp_RES_FINALIZE) {


### PR DESCRIPTION
as is done with known content-length

#441 first commit only to check QA