### PR TITLE
Decompress end v5

### DIFF
--- a/htp/htp_core.h
+++ b/htp/htp_core.h
@@ -212,7 +212,10 @@ enum htp_content_encoding_t {
     HTP_COMPRESSION_DEFLATE = 3,
 
     /** LZMA compression. */
-    HTP_COMPRESSION_LZMA = 4
+    HTP_COMPRESSION_LZMA = 4,
+
+    /** No more data. */
+    HTP_COMPRESSION_OVER = 5
 };
 
 /**

--- a/htp/htp_decompressors.c
+++ b/htp/htp_decompressors.c
@@ -203,6 +203,8 @@ htp_status_t htp_gzip_decompressor_decompress(htp_decompressor_t *drec1, htp_tx_
         }
 
         return HTP_OK;
+    } else if (drec->zlib_initialized == HTP_COMPRESSION_OVER) {
+        return HTP_ERROR;
     }
 
     if (d->data == NULL) {
@@ -316,15 +318,8 @@ restart:
             // no initialization means previous error on stream
             return HTP_ERROR;
         }
-        if (GZIP_BUF_SIZE > drec->stream.avail_out) {
-            if (rc == Z_DATA_ERROR && drec->restart == 0) {
-                // There is data even if there is an error
-                // So use this data and log a warning
-                htp_log(d->tx->connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "GZip decompressor: inflate failed with %d", rc);
-                rc = Z_STREAM_END;
-            }
-        }
-        if (rc == Z_STREAM_END) {
+        int error_after_data = (rc == Z_DATA_ERROR && drec->restart == 0 && GZIP_BUF_SIZE > drec->stream.avail_out);
+        if (rc == Z_STREAM_END || error_after_data) {
             // How many bytes do we have?
             size_t len = GZIP_BUF_SIZE - drec->stream.avail_out;
 
@@ -351,6 +346,13 @@ restart:
             drec->stream.next_out = drec->buffer;
             // TODO Handle trailer.
 
+            if (error_after_data) {
+                // There is data even if there is an error
+                // So use this data and log a warning
+                htp_log(d->tx->connp, HTP_LOG_MARK, HTP_LOG_WARNING, 0, "GZip decompressor: inflate failed with %d", rc);
+                drec->zlib_initialized = HTP_COMPRESSION_OVER;
+                return HTP_ERROR;
+            }
             return HTP_OK;
         }
         else if (rc != Z_OK) {

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -415,7 +415,7 @@ htp_status_t htp_connp_RES_BODY_CHUNKED_LENGTH(htp_connp_t *connp) {
 
         // Have we reached the end of the line? Or is this not chunked after all?
         if (connp->out_next_byte == LF ||
-                (!is_chunked_ctl_char((unsigned char) connp->out_next_byte) && !data_probe_chunk_length(connp))) {
+                (!is_chunked_ctl_char((unsigned char) connp->out_next_byte) && !data_probe_chunk_length(connp) && connp->out_buf == NULL)) {
             unsigned char *data;
             size_t len;
 

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -375,11 +375,6 @@ static inline int is_chunked_ctl_char(const unsigned char c) {
  * @returns 1 if it looks valid, 0 if it looks invalid
  */
 static inline int data_probe_chunk_length(htp_connp_t *connp) {
-    if (connp->out_current_read_offset - connp->out_current_consume_offset < 8) {
-        // not enough data so far, consider valid still
-        return 1;
-    }
-
     unsigned char *data = connp->out_current_data + connp->out_current_consume_offset;
     size_t len = connp->out_current_read_offset - connp->out_current_consume_offset;
 

--- a/htp/htp_response.c
+++ b/htp/htp_response.c
@@ -289,6 +289,12 @@ static void htp_connp_res_clear_buffer(htp_connp_t *connp) {
 htp_status_t htp_connp_RES_BODY_CHUNKED_DATA_END(htp_connp_t *connp) {
     // TODO We shouldn't really see anything apart from CR and LF,
     //      so we should warn about anything else.
+    if (connp->out_status == HTP_STREAM_CLOSED) {
+        connp->out_state = htp_connp_RES_FINALIZE;
+        // Sends close signal to decompressors
+        htp_status_t rc = htp_tx_res_process_body_data_ex(connp->out_tx, NULL, 0);
+        return rc;
+    }
 
     for (;;) {
         OUT_NEXT_BYTE_OR_RETURN(connp);
@@ -402,6 +408,13 @@ static inline int data_probe_chunk_length(htp_connp_t *connp) {
  * @returns HTP_OK on state change, HTP_ERROR on error, or HTP_DATA when more data is needed.
  */
 htp_status_t htp_connp_RES_BODY_CHUNKED_LENGTH(htp_connp_t *connp) {
+    if (connp->out_status == HTP_STREAM_CLOSED) {
+        connp->out_state = htp_connp_RES_FINALIZE;
+        // Sends close signal to decompressors
+        htp_status_t rc = htp_tx_res_process_body_data_ex(connp->out_tx, NULL, 0);
+        return rc;
+    }
+
     for (;;) {
         OUT_COPY_BYTE_OR_RETURN(connp);
 

--- a/htp/htp_transaction.c
+++ b/htp/htp_transaction.c
@@ -972,8 +972,13 @@ htp_status_t htp_tx_res_process_body_data_ex(htp_tx_t *tx, const void *data, siz
         case HTP_COMPRESSION_DEFLATE:
         case HTP_COMPRESSION_LZMA:
             // In severe memory stress these could be NULL
-            if (tx->connp->out_decompressor == NULL)
+            if (tx->connp->out_decompressor == NULL) {
+                if (data == NULL) {
+                    // we were already stopped on a gap finishing CL
+                    return HTP_OK;
+                }
                 return HTP_ERROR;
+            }
 
             struct timeval after;
             gettimeofday(&tx->connp->out_decompressor->time_before, NULL);


### PR DESCRIPTION
#446 with additional commit.

Waiting for QA, but looks good locally (sames hashes than libhtp.rs)

Reasons for patching libhtp.c for each commit :

- decompressors: do not take data after end :
flate2.rs does not accept data after end cf https://docs.rs/flate2/latest/flate2/write/struct.DeflateDecoder.html#method.try_finish for instance and this seems right. libhtp.c used to restart new, fail, and switch to passthrough.
Cases happen because of (not perfectly handled) gaps

- response: end decompressors in chunked content
libhtp.rs (by rust chained decoder construction) does not do the buffering up to 8192 bytes before flushing to C caller.
libhtp.c failed to flush some (gzipped) data in these cases (end of stream before file was complete)

- chunks: abort asap on invalid chunk length and chunks: probe validity if data was not buffered
libhtp.rs looks more sane :
1. do not wait for 8 bytes to probe chunk length line validity in case we did not get a full line
2. if data was buffered, do not probe validity as if it just started
Cases happen because of (not perfectly handled) gaps
There may be more to do here in C but it looks minimal change to get same behavior for QA

- response: do not error on gap finishing content-length
libhtp.rs is just right doing in `response_body_data` the following
```rust
                // Send data buffer to the decompressor if it exists
                if resp.response_decompressor.is_none() && data.is_none() {
                    return Ok(());
                }
```
so I changed libhtp.c. To change libhtp.rs behavior instead, just remove the mentioned code and let it go through `let mut decompressor = resp.response_decompressor.take().ok_or(HtpStatus::ERROR)?;`