### PR TITLE
request: do not fully error on data after HTTP/0.9

### DIFF
--- a/htp/htp_request.c
+++ b/htp/htp_request.c
@@ -1006,7 +1006,8 @@ int htp_connp_req_data(htp_connp_t *connp, const htp_time_t *timestamp, const vo
     }
 
     // Sanity check: we must have a transaction pointer if the state is not IDLE (no inbound transaction)
-    if ((connp->in_tx == NULL)&&(connp->in_state != htp_connp_REQ_IDLE)) {
+    if ((connp->in_tx == NULL)&&
+        (connp->in_state != htp_connp_REQ_IDLE && connp->in_state != htp_connp_REQ_IGNORE_DATA_AFTER_HTTP_0_9)) {
         connp->in_status = HTP_STREAM_ERROR;
 
         htp_log(connp, HTP_LOG_MARK, HTP_LOG_ERROR, 0, "Missing inbound transaction data");


### PR DESCRIPTION
QA has same errors as https://github.com/OISF/suricata/pull/12841 and next versions

https://github.com/OISF/libhtp/pull/449 with better commit message

Makes https://github.com/OISF/suricata-verify/pull/2372 pas