### PR TITLE
autotools: drop gnu99 as default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,11 @@ AC_PROG_CXX
 LT_INIT
 AM_SANITY_CHECK
 
+# Verify that the selected compiler actually supports C11
+AS_IF([test "x$ac_cv_prog_cc_c11" = "xno"], [
+       CFLAGS="${CFLAGS} -std=gnu99 -Wno-c11-extensions"
+       ])
+
 # Checks for library functions
 #AC_CHECK_FUNCS([strlcpy strlcat])
     OCFLAGS=$CFLAGS

--- a/htp/Makefile.am
+++ b/htp/Makefile.am
@@ -18,7 +18,7 @@ c_sources = bstr.c bstr_builder.c htp_base64.c htp_config.c htp_connection.c htp
 library_includedir = $(includedir)/$(GENERIC_LIBRARY_NAME)
 library_include_HEADERS = $(h_sources)
 
-AM_CFLAGS = -I$(top_srcdir) -I$(top_builddir)/htp -D_GNU_SOURCE -g -Wall -Wextra -std=gnu99 -pedantic \
+AM_CFLAGS = -I$(top_srcdir) -I$(top_builddir)/htp -D_GNU_SOURCE -g -Wall -Wextra -pedantic \
     -Wextra -Wno-missing-field-initializers -Wshadow -Wpointer-arith \
     -Wstrict-prototypes -Wmissing-prototypes -Wno-unused-parameter
 

--- a/htp/lzma/Makefile.am
+++ b/htp/lzma/Makefile.am
@@ -5,7 +5,7 @@ h_sources_private = LzFind.h LzHash.h Compiler.h Precomp.h
 
 c_sources = LzFind.c LzmaDec.c
 
-AM_CFLAGS = -I$(top_srcdir) -D_GNU_SOURCE -g -Wall -Wextra -std=gnu99 -pedantic \
+AM_CFLAGS = -I$(top_srcdir) -D_GNU_SOURCE -g -Wall -Wextra -pedantic \
     -Wextra -Wno-missing-field-initializers -Wshadow -Wpointer-arith \
     -Wstrict-prototypes -Wmissing-prototypes -Wno-unused-parameter
 

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -1,6 +1,6 @@
 LDADD = $(top_builddir)/htp/libhtp.la -lz @LIBICONV@ 
 
-AM_CFLAGS = -D_GNU_SOURCE -g -Wall -Wextra -std=gnu99 -pedantic \
+AM_CFLAGS = -D_GNU_SOURCE -g -Wall -Wextra -pedantic \
 	-Wextra -Wno-missing-field-initializers -Wshadow -Wpointer-arith \
         -Wstrict-prototypes -Wmissing-prototypes -Wno-unused-parameter
         


### PR DESCRIPTION
To address:

htp_util.c:623:32: warning: '_Generic' is a C11 extension [-Wc11-extensions]
  623 |         unsigned char *colon = memchr(data, ':', len);
      |                                ^
/usr/include/string.h:122:3: note: expanded from macro 'memchr'
  122 |   __glibc_const_generic (S, const void *, memchr (S, C, N))
      |   ^
/usr/include/x86_64-linux-gnu/sys/cdefs.h:838:3: note: expanded from macro '__glibc_const_generic'
  838 |   _Generic (0 ? (PTR) : (void *) 1,                     \
      |   ^
htp_util.c:799:32: warning: '_Generic' is a C11 extension [-Wc11-extensions]
  799 |             unsigned char *m = memchr(data + start, '@', pos - start);
      |                                ^
/usr/include/string.h:122:3: note: expanded from macro 'memchr'
  122 |   __glibc_const_generic (S, const void *, memchr (S, C, N))
      |   ^
/usr/include/x86_64-linux-gnu/sys/cdefs.h:838:3: note: expanded from macro '__glibc_const_generic'
  838 |   _Generic (0 ? (PTR) : (void *) 1,                     \
      |   ^
htp_util.c:810:21: warning: '_Generic' is a C11 extension [-Wc11-extensions]
  810 |                 m = memchr(credentials_start, ':', credentials_len);
      |                     ^
/usr/include/string.h:122:3: note: expanded from macro 'memchr'
  122 |   __glibc_const_generic (S, const void *, memchr (S, C, N))
      |   ^
/usr/include/x86_64-linux-gnu/sys/cdefs.h:838:3: note: expanded from macro '__glibc_const_generic'
  838 |   _Generic (0 ? (PTR) : (void *) 1,                     \
      |   ^
htp_util.c:832:21: warning: '_Generic' is a C11 extension [-Wc11-extensions]
  832 |                 m = memchr(hostname_start, ']', hostname_len);
      |                     ^
/usr/include/string.h:122:3: note: expanded from macro 'memchr'
  122 |   __glibc_const_generic (S, const void *, memchr (S, C, N))
      |   ^
/usr/include/x86_64-linux-gnu/sys/cdefs.h:838:3: note: expanded from macro '__glibc_const_generic'
  838 |   _Generic (0 ? (PTR) : (void *) 1,                     \
      |   ^
htp_util.c:846:25: warning: '_Generic' is a C11 extension [-Wc11-extensions]
  846 |                     m = memchr(hostname_start, ':', hostname_len);
      |                         ^
/usr/include/string.h:122:3: note: expanded from macro 'memchr'
  122 |   __glibc_const_generic (S, const void *, memchr (S, C, N))
      |   ^
/usr/include/x86_64-linux-gnu/sys/cdefs.h:838:3: note: expanded from macro '__glibc_const_generic'
  838 |   _Generic (0 ? (PTR) : (void *) 1,                     \
      |   ^
htp_util.c:856:21: warning: '_Generic' is a C11 extension [-Wc11-extensions]
  856 |                 m = memchr(hostname_start, ':', hostname_len);
      |                     ^
/usr/include/string.h:122:3: note: expanded from macro 'memchr'
  122 |   __glibc_const_generic (S, const void *, memchr (S, C, N))
      |   ^
/usr/include/x86_64-linux-gnu/sys/cdefs.h:838:3: note: expanded from macro '__glibc_const_generic'
  838 |   _Generic (0 ? (PTR) : (void *) 1,                     \
      |   ^
6 warnings generated.